### PR TITLE
Bugsnag.start not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
 ## Usage
 
 ```elixir
-# Turn the lights on.
-Bugsnag.start
 
 # Report an exception.
 try do


### PR DESCRIPTION
I don't think Bugsnag.start needs to be called because it is not implementing any server behaviours or creating and persistent processes.  It works fine without it