### PR TITLE
Autostart httpoison when starting bugsnag application

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ defp deps do
   [{:bugsnag, "~> 1.0.0"}]
 end
 
+# Now, list the :bugsnag application as your application dependency:
+def application do
+  [applications: [:bugsnag]]
+end
+
 # Open up your config/config.exs (or appropriate project config)
 config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
 ```
@@ -17,9 +22,6 @@ config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
 ## Usage
 
 ```elixir
-# Turn the lights on.
-Bugsnag.start
-
 # Report an exception.
 try do
   :foo = :bar

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bugsnag.Mixfile do
   def project do
     [app: :bugsnag,
      version: "1.1.1",
-     elixir: "~> 1.0.2",
+     elixir: "~> 1.0",
      package: package,
      description: """
        An Elixir interface to the Bugsnag API
@@ -19,7 +19,7 @@ defmodule Bugsnag.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [:httpoison]]
   end
 
   defp deps do


### PR DESCRIPTION
Bugsnag needs to start httpoison before using it. Otherwise when running in prod no reporting will silently fail.

I also updated the readme for best practise for starting applications.