### PR TITLE
relax elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bugsnag.Mixfile do
   def project do
     [app: :bugsnag,
      version: "1.1.1",
-     elixir: "~> 1.0.2",
+     elixir: "~> 1.0",
      package: package,
      description: """
        An Elixir interface to the Bugsnag API


### PR DESCRIPTION
With Elixir 1.1 released, the current Elixir version requirements for the library give me a warning:
`warning: the dependency :bugsnag requires Elixir "~> 1.0.2" but you are running on v1.1.0`

I don't think relaxing to 1.x would cause any issues?