### PR TITLE
Add metadata to payload

### DIFF
--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -14,7 +14,8 @@ defmodule Bugsnag.Payload do
                  stacktrace,
                  Keyword.get(options, :context),
                  Keyword.get(options, :severity),
-                 Keyword.get(options, :releaseStage))
+                 Keyword.get(options, :releaseStage),
+                 Keyword.get(options, :metadata))
   end
 
   defp add_api_key(payload) do
@@ -22,13 +23,14 @@ defmodule Bugsnag.Payload do
     |> Map.put :apiKey, Application.get_env(:bugsnag, :api_key)
   end
 
-  defp add_event(payload, exception, stacktrace, context, severity, releaseStage) do
+  defp add_event(payload, exception, stacktrace, context, severity, releaseStage, metadata) do
     event = %{}
     |> add_payload_version
     |> add_exception(exception, stacktrace)
     |> add_severity(severity)
     |> add_context(context)
     |> add_releaseStage(releaseStage)
+    |> add_metadata(metadata)
     Map.put payload, :events, [event]
   end
 
@@ -50,6 +52,9 @@ defmodule Bugsnag.Payload do
 
   defp add_context(event, nil), do: event
   defp add_context(event, context), do: Map.put(event, :context, context)
+
+  defp add_metadata(event, nil), do: event
+  defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)
 
   defp format_stacktrace(stacktrace) do
     Enum.map stacktrace, fn

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -30,6 +30,14 @@ defmodule Bugsnag.PayloadTest do
     assert "Potato#cake" == get_event(context: "Potato#cake").context
   end
 
+  test "it adds metadata when provided" do
+    metadata = %{some_data: %{some_more: "some string"}}
+    assert metadata == get_event(metadata: metadata).metaData
+  end
+
+  test "metaData is nil when not given" do
+    refute Map.has_key?(get_event, :metaData)
+  end
 
   test "it generates correct stacktraces" do
     {exception, stacktrace} = try do


### PR DESCRIPTION
add `metaData` to the payload to send arbitrary data to bugsnag per the open issue.  