### PR TITLE
remove runtime call to Mix.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ end
 
 # Open up your config/config.exs (or appropriate project config)
 config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
+
+# Set the release stage in your environment configs (e.g. config/prod.exs)
+config :bugsnag, release_stage: "prod"
 ```
 
 ## Usage

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -4,6 +4,7 @@ defmodule Bugsnag.Payload do
     version: Bugsnag.Mixfile.project[:version],
     url: Bugsnag.Mixfile.project[:package][:links][:github],
   }
+  @release_stage Application.get_env(:bugsnag, :release_stage) || "test"
 
   defstruct api_key: nil, notifier: @notifier_info, events: nil
 
@@ -26,7 +27,7 @@ defmodule Bugsnag.Payload do
       |> add_context(Keyword.get(options, :context))
       |> add_user(Keyword.get(options, :user))
       |> add_metadata(Keyword.get(options, :metadata))
-      |> add_release_stage(Keyword.get(options, :release_stage, to_string Mix.env))
+      |> add_release_stage(Keyword.get(options, :release_stage, @release_stage))
 
     Map.put payload, :events, [event]
   end


### PR DESCRIPTION
this replaces runtime calls to `Mix.env` with an application configuration `release_stage` as mix might not be available in exrm releases.