### PR TITLE
Add support for a custom stack trace

### DIFF
--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -6,12 +6,10 @@ defmodule Bugsnag do
   use HTTPoison.Base
 
   def report(exception, options \\ []) do
-    stacktrace = System.stacktrace
-    spawn fn ->
-      post(@notify_url,
-           Payload.new(exception, stacktrace, options) |> to_json,
-           @request_headers)
-    end
+    stacktrace = Keyword.get(options, :custom_stacktrace) || System.stacktrace
+    payload = Payload.new(exception, stacktrace, options) |> to_json
+
+    post(@notify_url, payload, @request_headers)
   end
 
   def to_json(payload) do

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -9,7 +9,9 @@ defmodule Bugsnag do
     stacktrace = Keyword.get(options, :custom_stacktrace) || System.stacktrace
     payload = Payload.new(exception, stacktrace, options) |> to_json
 
-    post(@notify_url, payload, @request_headers)
+    spawn fn ->
+      post(@notify_url, payload, @request_headers)
+    end
   end
 
   def to_json(payload) do

--- a/mix.exs
+++ b/mix.exs
@@ -13,9 +13,9 @@ defmodule Bugsnag.Mixfile do
   end
 
   def package do
-    [contributors: ["Jared Norman"],
+    [contributors: ["Jared Norman", "Rafael Albuquerque"],
      licenses: ["MIT"],
-     links: %{github: "https://github.com/jarednorman/bugsnag-elixir"}]
+     links: %{github: "https://github.com/Talkdesk/bugsnag-elixir"}]
   end
 
   def application do


### PR DESCRIPTION
Allow a custom stack trace to be supplied through the options hash through the `:custom_stacktrace` key.