### PR TITLE
Feature: Add error logger.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,2 @@
 use Mix.Config
 
-config :bugsnag,
-  api_key: System.get_env("BUGSNAG_API_KEY") || "FAKEKEY"

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -1,21 +1,29 @@
 defmodule Bugsnag do
+  use Application
+
+  alias Bugsnag.Payload
+
   @notify_url "https://notify.bugsnag.com"
   @request_headers [{"Content-Type", "application/json"}]
 
-  alias Bugsnag.Payload
-  use HTTPoison.Base
+  def start do
+  end
 
   def report(exception, options \\ []) do
-    stacktrace = System.stacktrace
+    stacktrace = options[:stacktrace] || System.stacktrace
+
     spawn fn ->
-      post(@notify_url,
-           Payload.new(exception, stacktrace, options) |> to_json,
-           @request_headers)
+      Payload.new(exception, stacktrace, options)
+        |> to_json
+        |> send_notification
     end
   end
 
   def to_json(payload) do
-    payload
-    |> Poison.encode!
+    payload |> Poison.encode!
+  end
+
+  defp send_notification(body) do
+    HTTPoison.post @notify_url, body, @request_headers
   end
 end

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -7,6 +7,14 @@ defmodule Bugsnag do
   @request_headers [{"Content-Type", "application/json"}]
 
   def start do
+    config = Keyword.merge default_config, Application.get_all_env(:bugsnag)
+
+    if config[:use_logger] do
+      :error_logger.add_report_handler(Bugsnag.Logger)
+    end
+
+    # put normalized api key to application config
+    Application.put_env(:bugsnag, :api_key, config[:api_key])
   end
 
   def report(exception, options \\ []) do
@@ -25,5 +33,12 @@ defmodule Bugsnag do
 
   defp send_notification(body) do
     HTTPoison.post @notify_url, body, @request_headers
+  end
+
+  defp default_config do
+    [
+      api_key: System.get_env("BUGSNAG_API_KEY") || "FAKEKEY",
+      use_logger: true
+    ]
   end
 end

--- a/lib/bugsnag/logger.ex
+++ b/lib/bugsnag/logger.ex
@@ -28,7 +28,7 @@ defmodule Bugsnag.Logger do
       end
     rescue
       ex ->
-        error_type = Error.normalize(:error, ex).__struct__
+        error_type = Exception.normalize(:error, ex).__struct__
                       |> Atom.to_string
                       |> String.replace(~r{\AElixir\.}, "")
 

--- a/lib/bugsnag/logger.ex
+++ b/lib/bugsnag/logger.ex
@@ -1,0 +1,46 @@
+defmodule Bugsnag.Logger do
+  require Bugsnag
+  require Logger
+
+  use GenEvent
+
+  def init(_mod, []), do: {:ok, []}
+
+  def handle_call({:configure, new_keys}, _state) do
+    {:ok, :ok, new_keys}
+  end
+
+  def handle_event({_level, gl, _event}, state)
+  when node(gl) != node() do
+    {:ok, state}
+  end
+
+  def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
+  when is_list(message) do
+    try do
+      error_info = message[:error_info]
+
+      case error_info do
+        {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
+          Bugsnag.report(exception, stacktrace: stacktrace)
+        {_kind, exception, stacktrace} ->
+          Bugsnag.report(exception, stacktrace: stacktrace)
+      end
+    rescue
+      ex ->
+        error_type = Error.normalize(:error, ex).__struct__
+                      |> Atom.to_string
+                      |> String.replace(~r{\AElixir\.}, "")
+
+        reason = Exception.message(ex)
+
+        Logger.warn "Unable to notify Bugsnag #{error_type}: #{reason}"
+    end
+
+    {:ok, state}
+  end
+
+  def handle_event({_level, _gl, _event}, state) do
+    {:ok, state}
+  end
+end

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -18,10 +18,12 @@ defmodule Bugsnag.Payload do
   end
 
   defp add_event(payload, exception, stacktrace, options) do
+    error = Exception.normalize(:error, exception)
+
     event =
       Map.new
       |> add_payload_version
-      |> add_exception(exception, stacktrace)
+      |> add_exception(error, stacktrace)
       |> add_severity(Keyword.get(options, :severity))
       |> add_context(Keyword.get(options, :context))
       |> add_user(Keyword.get(options, :user))

--- a/mix.exs
+++ b/mix.exs
@@ -19,11 +19,13 @@ defmodule Bugsnag.Mixfile do
   end
 
   def application do
-    [applications: [:httpoison]]
+    [applications: [:httpoison, :logger]]
   end
 
   defp deps do
     [{:httpoison, "~> 0.6"},
-     {:poison, "~> 1.3"}]
+     {:poison, "~> 1.3"},
+
+     {:meck, "~> 0.8.3", only: :test}]
   end
 end

--- a/test/bugsnag/logger_test.exs
+++ b/test/bugsnag/logger_test.exs
@@ -1,0 +1,84 @@
+defmodule Bugsnag.LoggerTest do
+  use ExUnit.Case
+  alias HTTPoison, as: HTTP
+
+  setup_all do
+    :error_logger.add_report_handler(Bugsnag.Logger)
+
+    on_exit fn ->
+      :error_logger.delete_report_handler(Bugsnag.Logger)
+    end
+  end
+
+  test "logging a crash" do
+    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+
+    :proc_lib.spawn fn ->
+      raise RuntimeError, "Oops"
+    end
+    :timer.sleep 250
+
+    assert :meck.called(HTTP, :post, [:_, :_, :_])
+    :meck.unload(HTTP)
+  end
+
+  test "crashes do not cause recursive logging" do
+    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Error{reason: 500} end)
+
+    error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
+
+    :error_logger.error_report(error_report)
+    :timer.sleep 250
+
+    assert :meck.called(HTTP, :post, [:_, :_, :_])
+    :meck.unload(HTTP)
+  end
+
+  test "log levels lower than :error_report are ignored" do
+    message_types = [:info_msg, :info_report, :warning_msg, :error_msg]
+
+    Enum.each(message_types, fn(type) ->
+      :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+      apply(:error_logger, type, ["Ignore me"])
+      :timer.sleep 250
+      refute :meck.called(HTTP, :post, [:_, :_, :_])
+    end)
+
+    :meck.unload(HTTP)
+  end
+
+  test "logging exceptions from special processes" do
+    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+
+    :proc_lib.spawn(fn ->
+      Float.parse("12.345e308")
+    end)
+    :timer.sleep 250
+
+    assert :meck.called(HTTP, :post, [:_, :_, :_])
+    :meck.unload(HTTP)
+  end
+
+  test "logging exceptions from Tasks" do
+    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+
+    Task.start(fn ->
+      Float.parse("12.345e308")
+    end)
+    :timer.sleep 250
+
+    assert :meck.called(HTTP, :post, [:_, :_, :_])
+    :meck.unload(HTTP)
+  end
+
+  test "logging exceptions from GenServers" do
+    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+
+    {:ok, pid} = ErrorServer.start
+    GenServer.cast(pid, :fail)
+    :timer.sleep 250
+
+    assert :meck.called(HTTP, :post, [:_, :_, :_])
+    :meck.unload(HTTP)
+  end
+end

--- a/test/bugsnag/logger_test.exs
+++ b/test/bugsnag/logger_test.exs
@@ -1,5 +1,8 @@
 defmodule Bugsnag.LoggerTest do
   use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
   alias HTTPoison, as: HTTP
 
   setup_all do
@@ -25,24 +28,31 @@ defmodule Bugsnag.LoggerTest do
   test "crashes do not cause recursive logging" do
     :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Error{reason: 500} end)
 
-    error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
+    log_msg = capture_log fn ->
+      error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
+      :error_logger.error_report(error_report)
+      :timer.sleep 250
+    end
 
-    :error_logger.error_report(error_report)
-    :timer.sleep 250
-
+    assert log_msg =~ "[[error_info: {:error, %RuntimeError{message: \"Oops\"}, []}], []]"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
+
     :meck.unload(HTTP)
   end
 
   test "log levels lower than :error_report are ignored" do
     message_types = [:info_msg, :info_report, :warning_msg, :error_msg]
 
-    Enum.each(message_types, fn(type) ->
-      :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
-      apply(:error_logger, type, ["Ignore me"])
-      :timer.sleep 250
-      refute :meck.called(HTTP, :post, [:_, :_, :_])
-    end)
+    Enum.each message_types, fn(type) ->
+      log_msg = capture_log fn ->
+        :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+        apply(:error_logger, type, ["Ignore me"])
+        :timer.sleep 250
+        refute :meck.called(HTTP, :post, [:_, :_, :_])
+      end
+
+      assert log_msg =~ "Ignore me"
+    end
 
     :meck.unload(HTTP)
   end
@@ -50,9 +60,9 @@ defmodule Bugsnag.LoggerTest do
   test "logging exceptions from special processes" do
     :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
 
-    :proc_lib.spawn(fn ->
+    :proc_lib.spawn fn ->
       Float.parse("12.345e308")
-    end)
+    end
     :timer.sleep 250
 
     assert :meck.called(HTTP, :post, [:_, :_, :_])
@@ -62,12 +72,14 @@ defmodule Bugsnag.LoggerTest do
   test "logging exceptions from Tasks" do
     :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
 
-    Task.start(fn ->
-      Float.parse("12.345e308")
-    end)
-    :timer.sleep 250
+    log_msg = capture_log fn ->
+      Task.start fn -> Float.parse("12.345e308") end
+      :timer.sleep 250
+    end
 
+    assert log_msg =~ "(ArgumentError) argument error"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
+
     :meck.unload(HTTP)
   end
 
@@ -75,10 +87,15 @@ defmodule Bugsnag.LoggerTest do
     :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
 
     {:ok, pid} = ErrorServer.start
-    GenServer.cast(pid, :fail)
-    :timer.sleep 250
 
+    log_msg = capture_log fn ->
+      GenServer.cast(pid, :fail)
+      :timer.sleep 250
+    end
+
+    assert log_msg =~ "(stop) bad cast: :fail"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
+
     :meck.unload(HTTP)
   end
 end

--- a/test/support/error_server.exs
+++ b/test/support/error_server.exs
@@ -1,0 +1,13 @@
+defmodule ErrorServer do
+  use GenServer
+
+  def start do
+    GenServer.start(__MODULE__, [])
+  end
+
+  def init(_), do: {:ok, []}
+
+  def handle_cast(:fail, _from, _state) do
+    raise RuntimeError, "Crashing"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
+Code.load_file("test/support/error_server.exs")
 ExUnit.start
 Bugsnag.start


### PR DESCRIPTION
Props to Honeybadger, as this work was heavily based on their Logger. Basically it sends error reports from OTP/tasks/processes/etc. So you don't need to manually wrap every expression within try/rescue block.