### PR TITLE
Adds ability to override the configured api_key via option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ They can be passed into the `Bugsnag.report/2` function like so:
   Bugsnag.report(exception, severity: "warn", user: %{name: "Jane Doe"})
 ```
 
+- `api_key` - Allows overriding any configured api key manually
 - `stacktrace` - Allows explicitly passing in a stacktrace used to generate the stacktrace object that is sent to bugsnag
 - `severity` - Sets the severity explicitly to "error", "warning" or "info"
 - `release_stage` - Explicitly sets an arbitrary release stage e.g. "development", "test" or "production"

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -9,13 +9,11 @@ defmodule Bugsnag.Payload do
 
   def new(exception, stacktrace, options) do
     %__MODULE__{}
-    |> add_api_key
+    |> add_api_key(Keyword.get(options, :api_key, Application.get_env(:bugsnag, :api_key, "FAKEKEY")))
     |> add_event(exception, stacktrace, options)
   end
 
-  defp add_api_key(payload) do
-    Map.put payload, :apiKey, Application.get_env(:bugsnag, :api_key)
-  end
+  defp add_api_key(payload, key), do: Map.put payload, :apiKey, key
 
   defp add_event(payload, exception, stacktrace, options) do
     error = Exception.normalize(:error, exception)

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -97,8 +97,14 @@ defmodule Bugsnag.PayloadTest do
     assert "2" == get_event.payloadVersion
   end
 
-  test "it sets the API key" do
-    assert Application.get_env(:bugsnag, :api_key) == get_payload.apiKey
+  test "it sets the API key if configured" do
+    Application.put_env(:bugsnag, :api_key, "testkey")
+    assert "testkey" == get_payload.apiKey
+  end
+
+  test "it sets the API key from options, even when configured" do
+    Application.put_env(:bugsnag, :api_key, "testkey")
+    assert "anotherkey" == get_payload(api_key: "anotherkey").apiKey
   end
 
   test "is sets the device info if given" do


### PR DESCRIPTION
~~Since #29 adds documentation for the options, this kinda depends on that PR... and we might wanna merge #29 first and update this afterwards.~~

(did that)