### PR TITLE
Adds support for synchronous reports via `Bugsnag.sync_report/2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ rescue
 end
 ```
 
+In some cases you might want to send the report synchronously, to make sure that it got sent. You can do that with:
+
+```elixir
+# ...an exception occured
+  Bugsnag.sync_report(exception)
+```
+
 ### Options
 
 These are optional fields to fill the bugsnag report with more information, depending on your specific usage scenario.

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Bugsnag.Mixfile do
   end
 
   defp deps do
-    [{:httpoison, "~> 0.6"},
+    [{:httpoison, "~> 0.9"},
      {:poison, "~> 1.5 or ~> 2.0"},
 
      {:meck, "~> 0.8.3", only: :test}]

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -9,6 +9,10 @@ defmodule BugsnagTest do
     end
   end
 
+  test "it returns proper results if you use sync_report" do
+    assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
+  end
+
   test "it handles real errors" do
     try do
       :foo = :bar


### PR DESCRIPTION
As mentioned briefly in an (admittely only barely related issue) I added support for calling the `Bugsnag.report/2` API synchronously via `Bugsnag.sync_report/2`.

This doesn't  break backwards compatibility.

Thoughts, @mootpointer ?
