### PR TITLE
Enable app to be started automatically by Mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ config :bugsnag, api_key: "bbf085fc54ff99498ebd18ab49a832dd"
 
 # Set the release stage in your environment configs (e.g. config/prod.exs)
 config :bugsnag, release_stage: "prod"
+
+# Set `use_logger: true` to report all uncaught exceptions (using Erlang SASL)
+config :bugsnag, use_logger: true
 ```
 
 ## Usage
@@ -60,7 +63,7 @@ They can be passed into the `Bugsnag.report/2` function like so:
 ### Logger
 
 Set the `use_logger` option to true in your application's `config.exs`.
-Then run `Bugsnag.start` and any [SASL](http://www.erlang.org/doc/apps/sasl/error_logging.html)
+So long as `:bugsnag` is started, any [SASL](http://www.erlang.org/doc/apps/sasl/error_logging.html)
 compliant processes that crash will send an error report to the `Bugsnag.Logger`.
 The logger will take care of sending the error to Bugsnag.
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -15,6 +15,7 @@ defmodule Bugsnag do
 
     # put normalized api key to application config
     Application.put_env(:bugsnag, :api_key, config[:api_key])
+    {:ok, self}
   end
 
   def report(exception, options \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule Bugsnag.Mixfile do
   end
 
   def application do
-    [applications: [:httpoison, :logger]]
+    [applications: [:httpoison, :logger],
+     mod: {Bugsnag, []}]
   end
 
   defp deps do


### PR DESCRIPTION
Adds `mod: {Bugsnag, []}` to the application definition in mix.exs,
which means that Mix can start the app correctly, and automatically pick
up uncaught exceptions when `use_logger: true` is set.

I think this makes this more intuitive to use - just set the config in `config/config.exs`, add it to your `applications` list in `mix.exs` and off you go.