### PR TITLE
use latest version of poison

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Bugsnag.Mixfile do
 
   defp deps do
     [{:httpoison, "~> 0.9"},
-     {:poison, "~> 1.5 or ~> 2.0"},
+     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
      {:meck, "~> 0.8.3", only: :test}]
   end


### PR DESCRIPTION
Based on the discussion in #25 I used `or` so that backwards compatibility won't be removed. Assuming the tests are comprehensive, the change doesn't break anything in the library. Thanks!