### PR TITLE
Add hostname config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can use environment variables in order to set up all options. You can set de
 - `BUGSNAG_USE_LOGGER`
 - `BUGSNAG_RELEASE_STAGE`
 - `BUGSNAG_NOTIFY_RELEASE_STAGES`
+- `HOSTNAME`
 
 Or you can define from which env vars it should be loaded, eg:
 
@@ -52,6 +53,7 @@ config :bugsnag, :endpoint_url,   {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :release_stage,  {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :notify_release_stages,  {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :use_logger,     {:system, "YOUR_ENV_VAR" [, optional_default]}
+config :bugsnag, :hostname,       {:system, "YOUR_ENV_VAR" [, optional_default]}
 ```
 
 Ofcourse you can use regular values as in Installation guide.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can use environment variables in order to set up all options. You can set de
 - `BUGSNAG_USE_LOGGER`
 - `BUGSNAG_RELEASE_STAGE`
 - `BUGSNAG_NOTIFY_RELEASE_STAGES`
-- `HOSTNAME`
+- `BUGSNAG_HOSTNAME`
 
 Or you can define from which env vars it should be loaded, eg:
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -99,7 +99,7 @@ defmodule Bugsnag do
       use_logger:    {:system, "BUGSNAG_USE_LOGGER", true},
       release_stage: {:system, "BUGSNAG_RELEASE_STAGE", "production"},
       notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]},
-      hostname:      {:system, "HOSTNAME", "unknown"}
+      hostname:      {:system, "BUGSNAG_HOSTNAME", "unknown"}
     ]
   end
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -98,7 +98,8 @@ defmodule Bugsnag do
       endpoint_url:  {:system, "BUGSNAG_ENDPOINT_URL", @notify_url},
       use_logger:    {:system, "BUGSNAG_USE_LOGGER", true},
       release_stage: {:system, "BUGSNAG_RELEASE_STAGE", "production"},
-      notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]}
+      notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]},
+      hostname:      {:system, "HOSTNAME", "unknown"}
     ]
   end
 

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -35,6 +35,7 @@ defmodule Bugsnag.Payload do
       |> add_metadata(Keyword.get(options, :metadata))
       |> add_release_stage(fetch_option(options, :release_stage, "production"))
       |> add_notify_release_stages(fetch_option(options, :notify_release_stages, ["production"]))
+      |> add_hostname(fetch_option(options, :hostname))
 
     Map.put payload, :events, [event]
   end
@@ -71,6 +72,9 @@ defmodule Bugsnag.Payload do
     do:   event,
     else: Map.put(event, :device, device)
   end
+
+  defp add_hostname(event, nil), do: event
+  defp add_hostname(event, hostname), do: Map.put(event, :hostname, hostname)
 
   defp add_metadata(event, nil), do: event
   defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -31,11 +31,10 @@ defmodule Bugsnag.Payload do
       |> add_severity(Keyword.get(options, :severity))
       |> add_context(Keyword.get(options, :context))
       |> add_user(Keyword.get(options, :user))
-      |> add_device(Keyword.get(options, :os_version), Keyword.get(options, :hostname))
+      |> add_device(Keyword.get(options, :os_version), fetch_option(options, :hostname, "unknown"))
       |> add_metadata(Keyword.get(options, :metadata))
       |> add_release_stage(fetch_option(options, :release_stage, "production"))
       |> add_notify_release_stages(fetch_option(options, :notify_release_stages, ["production"]))
-      |> add_hostname(fetch_option(options, :hostname))
 
     Map.put payload, :events, [event]
   end
@@ -72,9 +71,6 @@ defmodule Bugsnag.Payload do
     do:   event,
     else: Map.put(event, :device, device)
   end
-
-  defp add_hostname(event, nil), do: event
-  defp add_hostname(event, hostname), do: Map.put(event, :hostname, hostname)
 
   defp add_metadata(event, nil), do: event
   defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -118,6 +118,11 @@ defmodule Bugsnag.PayloadTest do
     assert "some-host"        == evt.device.hostname
   end
 
+  test "it reports the hostname in the application's config if specified" do
+    assert "unknown" == get_event().device.hostname
+    assert "some-host" == get_event(hostname: "some-host").device.hostname
+  end
+
   test "it reports the notifier" do
     assert %{name: "Bugsnag Elixir",
              url: "https://github.com/jarednorman/bugsnag-elixir",


### PR DESCRIPTION
This should allow setting the `hostname` in a config which will then report it to the Device tab and the Summaries sidebar in Bugsnag.
```
config :bugsnag,
  client: Bugnsnag,
  api_key: System.get_env("BUGSNAG_API_KEY"),
  hostname: System.get_env("HOSTNAME"),
  ...
```
In this case the application is released in a container. Currently the Bugsnags are not reported with a device tab even if the the `hostname` is set in the config. Using the `fetch_option` function it will default to using the the application environment set to `[:bugsnag][:hostname]` if it is not in the `options` map.