### PR TITLE
Update build matrix: remove Elixir 1.2, add 1.5 and 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: elixir
 elixir:
-    - 1.2.2
-    - 1.3.2
-    - 1.4.1
+    - 1.3.4
+    - 1.4.5
+    - 1.5.3
+    - 1.6.3
 otp_release:
-    - 18.2.1
-    - 19.2
+    - 19.3.6
+    - 20.2.4
 
 matrix:
-  # Elixir 1.2.x is not compatible with Erlang R19
   exclude:
-    - elixir: 1.2.2
-      otp_release: 19.2
+    - elixir: 1.3.4
+      otp_release: 20.2.4

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bugsnag.Mixfile do
   def project do
     [app: :bugsnag,
      version: "1.5.0",
-     elixir: "~> 1.0",
+     elixir: "~> 1.3",
      package: package(),
      description: """
        An Elixir interface to the Bugsnag API


### PR DESCRIPTION
This seemed like it could use a cleanup, especially since the Elixir and OTP versions we're testing have had several patch releases since the last update to this file.

Regarding version support: I'm taking a cue from Phoenix here, which currently supports Elixir 1.3+. This still gives us coverage for 3 previous releases of Elixir, and allows us to drop OTP 18.