### PR TITLE
Warn when API key is not configured

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,2 +1,3 @@
 use Mix.Config
 
+if Mix.env == :test, do: config :bugsnag, :api_key, "FAKEKEY"

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -23,9 +23,6 @@ defmodule Bugsnag do
       Application.put_env :bugsnag, k, v
     end
 
-    # put normalized api key to application config
-    Application.put_env(:bugsnag, :api_key, config[:api_key])
-
     children = [
       supervisor(Task.Supervisor, [[name: Bugsnag.TaskSupervisor, restart: :transient]])
     ]

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -37,12 +37,39 @@ defmodule BugsnagTest do
     assert Application.get_env(:bugsnag, :notify_release_stages) == ["production"]
   end
 
+  test "it warns if no api_key is configured" do
+    {:ok, old_key} = Application.fetch_env(:bugsnag, :api_key)
+    Application.delete_env(:bugsnag, :api_key)
+    on_exit fn -> Application.put_env(:bugsnag, :api_key, old_key) end
+
+    assert capture_log(fn -> Bugsnag.start(:temporary, %{}) end) =~ "api_key is not configured"
+  end
+
+  test "it doesn't warn about api_key if the current release stage is not a notifying one" do
+    {:ok, old_stage} = Application.fetch_env(:bugsnag, :release_stage)
+    Application.put_env(:bugsnag, :release_stage, "development")
+    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_stage) end
+
+    assert capture_log(fn -> Bugsnag.start(:temporary, %{}) end) == ""
+  end
+
   test "it should not explode with logger unset" do
     Application.put_env(:bugsnag, :use_logger, nil)
     on_exit fn -> Application.put_env(:bugsnag, :use_logger, true) end
 
     Bugsnag.start(:temporary, %{})
     assert Application.get_env(:bugsnag, :use_logger) == nil
+  end
+
+  test "warns and returns an error when sending a report with no API key configured" do
+    {:ok, old_key} = Application.fetch_env(:bugsnag, :api_key)
+    Application.delete_env(:bugsnag, :api_key)
+    on_exit fn -> Application.put_env(:bugsnag, :api_key, old_key) end
+
+    log = capture_log fn ->
+      assert {:error, %{reason: "API key is not configured"}} == Bugsnag.sync_report("error!")
+    end
+    assert log =~ "api_key is not configured"
   end
 
   test "does not notify bugsnag if you use sync_report and release_stage is not included in the notify_release_stages" do

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -30,8 +30,7 @@ defmodule BugsnagTest do
       "{\"foo\":3,\"bar\":\"baz\"}"
   end
 
-  test "it properly sets config" do
-    Bugsnag.start(:ok, :ok)
+  test "it puts application env values on startup" do
     assert Application.get_env(:bugsnag, :release_stage) == "production"
     assert Application.get_env(:bugsnag, :api_key) == "FAKEKEY"
     assert Application.get_env(:bugsnag, :use_logger) == true

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,3 @@
 Code.load_file("test/support/error_server.exs")
 
-Bugsnag.start(:ok, :ok)
-
 ExUnit.start


### PR DESCRIPTION
An updated take on #34. Rather than crashing only once we try to report an error, the app will fail to start entirely if no `api_key` is present and we are in a "notifying" release stage.

Like the original, this is backwards-incompatible, in that misconfigured apps that used to "work" will now crash. Not sure if this warrants a major-version bump. @coburncoburn, thoughts?