### PR TITLE
Replacing Elixir GenEvent with :gen_event to avoid Elixir complaining

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-if Mix.env == :test, do: config :bugsnag, :api_key, "FAKEKEY"
+if Mix.env() == :test, do: config(:bugsnag, :api_key, "FAKEKEY")

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -9,20 +9,21 @@ defmodule Bugsnag do
   @request_headers [{"Content-Type", "application/json"}]
 
   def start(_type, _args) do
-    config = default_config()
-    |> Keyword.merge(Application.get_all_env(:bugsnag))
-    |> Enum.map(fn {k, v} -> {k, eval_config(v)} end)
+    config =
+      default_config()
+      |> Keyword.merge(Application.get_all_env(:bugsnag))
+      |> Enum.map(fn {k, v} -> {k, eval_config(v)} end)
 
-    if (config[:use_logger] |> to_string) == "true" do
+    if config[:use_logger] |> to_string == "true" do
       :error_logger.add_report_handler(Bugsnag.Logger)
     end
 
     # Update Application config with evaluated configuration
     # It's needed for use in Bugsnag.Payload, could be removed
     # by using GenServer instead of this kind of app.
-    Enum.each config, fn {k, v} ->
-      Application.put_env :bugsnag, k, v
-    end
+    Enum.each(config, fn {k, v} ->
+      Application.put_env(:bugsnag, k, v)
+    end)
 
     if !config[:api_key] and should_notify() do
       Logger.warn("Bugsnag api_key is not configured, errors will not be reported")
@@ -41,22 +42,21 @@ defmodule Bugsnag do
   (I.e. this might fail silently)
   """
   def report(exception, options \\ []) do
-    Task.Supervisor.start_child(
-      Bugsnag.TaskSupervisor,
-      __MODULE__,
-      :sync_report,
-      [exception, add_stacktrace(options)]
-    )
+    Task.Supervisor.start_child(Bugsnag.TaskSupervisor, __MODULE__, :sync_report, [
+      exception,
+      add_stacktrace(options)
+    ])
   end
 
   defp add_stacktrace(options) when is_list(options) do
-    Keyword.put_new(options, :stacktrace, System.stacktrace)
+    Keyword.put_new(options, :stacktrace, System.stacktrace())
   end
+
   defp add_stacktrace(options), do: options
 
   @doc "Report the exception and wait for the result. Returns `ok` or `{:error, reason}`."
   def sync_report(exception, options \\ []) do
-    stacktrace = options[:stacktrace] || System.stacktrace
+    stacktrace = options[:stacktrace] || System.stacktrace()
 
     if should_notify() do
       if Application.get_env(:bugsnag, :api_key) do
@@ -64,10 +64,10 @@ defmodule Bugsnag do
         |> to_json
         |> send_notification
         |> case do
-          {:ok, %{status_code: 200}}   -> :ok
+          {:ok, %{status_code: 200}} -> :ok
           {:ok, %{status_code: other}} -> {:error, "status_#{other}"}
-          {:error, %{reason: reason}}  -> {:error, reason}
-          _                            -> {:error, :unknown}
+          {:error, %{reason: reason}} -> {:error, reason}
+          _ -> {:error, :unknown}
         end
       else
         Logger.warn("Bugsnag api_key is not configured, error not reported")
@@ -79,7 +79,7 @@ defmodule Bugsnag do
   end
 
   def to_json(payload) do
-    payload |> Poison.encode!
+    payload |> Poison.encode!()
   end
 
   defp send_notification(body) do
@@ -89,14 +89,16 @@ defmodule Bugsnag do
   def should_notify do
     release_stage = Application.get_env(:bugsnag, :release_stage)
     notify_release_stages = Application.get_env(:bugsnag, :notify_release_stages)
-    release_stage && is_list(notify_release_stages) && Enum.member?(notify_release_stages, release_stage)
+
+    release_stage && is_list(notify_release_stages) &&
+      Enum.member?(notify_release_stages, release_stage)
   end
 
   defp default_config do
     [
-      api_key:       {:system, "BUGSNAG_API_KEY", nil},
-      endpoint_url:  {:system, "BUGSNAG_ENDPOINT_URL", @notify_url},
-      use_logger:    {:system, "BUGSNAG_USE_LOGGER", true},
+      api_key: {:system, "BUGSNAG_API_KEY", nil},
+      endpoint_url: {:system, "BUGSNAG_ENDPOINT_URL", @notify_url},
+      use_logger: {:system, "BUGSNAG_USE_LOGGER", true},
       release_stage: {:system, "BUGSNAG_RELEASE_STAGE", "production"},
       notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]}
     ]

--- a/lib/bugsnag/logger.ex
+++ b/lib/bugsnag/logger.ex
@@ -2,39 +2,41 @@ defmodule Bugsnag.Logger do
   require Bugsnag
   require Logger
 
-  use GenEvent
+  @behaviour :gen_event
 
-  def init(_mod, []), do: {:ok, []}
+  def init(_init_args), do: {:ok, []}
 
   def handle_call({:configure, new_keys}, _state) do
     {:ok, :ok, new_keys}
   end
 
   def handle_event({_level, gl, _event}, state)
-  when node(gl) != node() do
+      when node(gl) != node() do
     {:ok, state}
   end
 
   def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
-  when is_list(message) do
+      when is_list(message) do
     try do
       error_info = message[:error_info]
 
       case error_info do
         {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
           Bugsnag.report(exception, stacktrace: stacktrace)
+
         {_kind, exception, stacktrace} ->
           Bugsnag.report(exception, stacktrace: stacktrace)
       end
     rescue
       ex ->
-        error_type = Exception.normalize(:error, ex).__struct__
-                      |> Atom.to_string
-                      |> String.replace(~r{\AElixir\.}, "")
+        error_type =
+          Exception.normalize(:error, ex).__struct__
+          |> Atom.to_string()
+          |> String.replace(~r{\AElixir\.}, "")
 
         reason = Exception.message(ex)
 
-        Logger.warn "Unable to notify Bugsnag #{error_type}: #{reason}"
+        Logger.warn("Unable to notify Bugsnag #{error_type}: #{reason}")
     end
 
     {:ok, state}

--- a/mix.exs
+++ b/mix.exs
@@ -2,32 +2,37 @@ defmodule Bugsnag.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :bugsnag,
-     version: "1.5.0",
-     elixir: "~> 1.3",
-     package: package(),
-     description: """
-       An Elixir interface to the Bugsnag API
-     """,
-     deps: deps()]
+    [
+      app: :bugsnag,
+      version: "1.5.0",
+      elixir: "~> 1.3",
+      package: package(),
+      description: """
+        An Elixir interface to the Bugsnag API
+      """,
+      deps: deps()
+    ]
   end
 
   def package do
-    [contributors: ["Jared Norman", "Andrew Harvey"],
-     maintainers: ["Andrew Harvey"],
-     licenses: ["MIT"],
-     links: %{github: "https://github.com/jarednorman/bugsnag-elixir"}]
+    [
+      contributors: ["Jared Norman", "Andrew Harvey"],
+      maintainers: ["Andrew Harvey"],
+      licenses: ["MIT"],
+      links: %{github: "https://github.com/jarednorman/bugsnag-elixir"}
+    ]
   end
 
   def application do
-    [applications: [:httpoison, :logger],
-     mod: {Bugsnag, []}]
+    [applications: [:httpoison, :logger], mod: {Bugsnag, []}]
   end
 
   defp deps do
-    [{:httpoison, "~> 0.9"},
-     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
-     {:ex_doc, ">= 0.0.0", only: :dev},
-     {:meck, "~> 0.8.3", only: :test}]
+    [
+      {:httpoison, "~> 0.9"},
+      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:meck, "~> 0.8.3", only: :test}
+    ]
   end
 end

--- a/test/bugsnag/logger_test.exs
+++ b/test/bugsnag/logger_test.exs
@@ -8,37 +8,39 @@ defmodule Bugsnag.LoggerTest do
   setup_all do
     :error_logger.add_report_handler(Bugsnag.Logger)
 
-    on_exit fn ->
+    on_exit(fn ->
       :error_logger.delete_report_handler(Bugsnag.Logger)
-    end
+    end)
 
     Application.put_env(:bugsnag, :release_stage, "test")
     Application.put_env(:bugsnag, :notify_release_stages, ["test"])
 
-    on_exit fn -> Application.delete_env(:bugsnag, :release_stage) end
-    on_exit fn -> Application.delete_env(:bugsnag, :notify_release_stages) end
+    on_exit(fn -> Application.delete_env(:bugsnag, :release_stage) end)
+    on_exit(fn -> Application.delete_env(:bugsnag, :notify_release_stages) end)
   end
 
   test "logging a crash" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    :proc_lib.spawn fn ->
+    :proc_lib.spawn(fn ->
       raise RuntimeError, "Oops"
-    end
-    :timer.sleep 250
+    end)
+
+    :timer.sleep(250)
 
     assert :meck.called(HTTP, :post, [:_, :_, :_])
     :meck.unload(HTTP)
   end
 
   test "crashes do not cause recursive logging" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Error{reason: 500} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Error{reason: 500} end)
 
-    log_msg = capture_log fn ->
-      error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
-      :error_logger.error_report(error_report)
-      :timer.sleep 250
-    end
+    log_msg =
+      capture_log(fn ->
+        error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
+        :error_logger.error_report(error_report)
+        :timer.sleep(250)
+      end)
 
     assert log_msg =~ "[[error_info: {:error, %RuntimeError{message: \"Oops\"}, []}], []]"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
@@ -49,39 +51,42 @@ defmodule Bugsnag.LoggerTest do
   test "log levels lower than :error_report are ignored" do
     message_types = [:info_msg, :info_report, :warning_msg, :error_msg]
 
-    Enum.each message_types, fn(type) ->
-      log_msg = capture_log fn ->
-        :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
-        apply(:error_logger, type, ["Ignore me"])
-        :timer.sleep 250
-        refute :meck.called(HTTP, :post, [:_, :_, :_])
-      end
+    Enum.each(message_types, fn type ->
+      log_msg =
+        capture_log(fn ->
+          :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
+          apply(:error_logger, type, ["Ignore me"])
+          :timer.sleep(250)
+          refute :meck.called(HTTP, :post, [:_, :_, :_])
+        end)
 
       assert log_msg =~ "Ignore me"
-    end
+    end)
 
     :meck.unload(HTTP)
   end
 
   test "logging exceptions from special processes" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    :proc_lib.spawn fn ->
+    :proc_lib.spawn(fn ->
       Float.parse("12.345e308")
-    end
-    :timer.sleep 250
+    end)
+
+    :timer.sleep(250)
 
     assert :meck.called(HTTP, :post, [:_, :_, :_])
     :meck.unload(HTTP)
   end
 
   test "logging exceptions from Tasks" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    log_msg = capture_log fn ->
-      Task.start fn -> Float.parse("12.345e308") end
-      :timer.sleep 250
-    end
+    log_msg =
+      capture_log(fn ->
+        Task.start(fn -> Float.parse("12.345e308") end)
+        :timer.sleep(250)
+      end)
 
     assert log_msg =~ "(ArgumentError) argument error"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
@@ -90,14 +95,15 @@ defmodule Bugsnag.LoggerTest do
   end
 
   test "logging exceptions from GenServers" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    {:ok, pid} = ErrorServer.start
+    {:ok, pid} = ErrorServer.start()
 
-    log_msg = capture_log fn ->
-      GenServer.cast(pid, :fail)
-      :timer.sleep 250
-    end
+    log_msg =
+      capture_log(fn ->
+        GenServer.cast(pid, :fail)
+        :timer.sleep(250)
+      end)
 
     # We assert either of these log messages because the log changed between elixir
     # versions. It feels like we shouldn't need to assert on the log message but...

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -4,15 +4,15 @@ defmodule BugsnagTest do
   import ExUnit.CaptureLog
 
   test "it doesn't raise errors if you report garbage" do
-    capture_log fn ->
+    capture_log(fn ->
       Bugsnag.report(Enum, %{ignore: :this_error_in_test})
-    end
+    end)
   end
 
   test "it returns proper results if you use sync_report" do
     old_release_stage = Application.get_env(:bugsnag, :release_stage)
     Application.put_env(:bugsnag, :release_stage, "production")
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
 
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
@@ -26,8 +26,7 @@ defmodule BugsnagTest do
   end
 
   test "it can encode json" do
-    assert Bugsnag.to_json(%{foo: 3, bar: "baz"}) ==
-      "{\"foo\":3,\"bar\":\"baz\"}"
+    assert Bugsnag.to_json(%{foo: 3, bar: "baz"}) == "{\"foo\":3,\"bar\":\"baz\"}"
   end
 
   test "it puts application env values on startup" do
@@ -40,7 +39,7 @@ defmodule BugsnagTest do
   test "it warns if no api_key is configured" do
     {:ok, old_key} = Application.fetch_env(:bugsnag, :api_key)
     Application.delete_env(:bugsnag, :api_key)
-    on_exit fn -> Application.put_env(:bugsnag, :api_key, old_key) end
+    on_exit(fn -> Application.put_env(:bugsnag, :api_key, old_key) end)
 
     assert capture_log(fn -> Bugsnag.start(:temporary, %{}) end) =~ "api_key is not configured"
   end
@@ -48,14 +47,14 @@ defmodule BugsnagTest do
   test "it doesn't warn about api_key if the current release stage is not a notifying one" do
     {:ok, old_stage} = Application.fetch_env(:bugsnag, :release_stage)
     Application.put_env(:bugsnag, :release_stage, "development")
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_stage) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_stage) end)
 
     assert capture_log(fn -> Bugsnag.start(:temporary, %{}) end) == ""
   end
 
   test "it should not explode with logger unset" do
     Application.put_env(:bugsnag, :use_logger, nil)
-    on_exit fn -> Application.put_env(:bugsnag, :use_logger, true) end
+    on_exit(fn -> Application.put_env(:bugsnag, :use_logger, true) end)
 
     Bugsnag.start(:temporary, %{})
     assert Application.get_env(:bugsnag, :use_logger) == nil
@@ -64,18 +63,20 @@ defmodule BugsnagTest do
   test "warns and returns an error when sending a report with no API key configured" do
     {:ok, old_key} = Application.fetch_env(:bugsnag, :api_key)
     Application.delete_env(:bugsnag, :api_key)
-    on_exit fn -> Application.put_env(:bugsnag, :api_key, old_key) end
+    on_exit(fn -> Application.put_env(:bugsnag, :api_key, old_key) end)
 
-    log = capture_log fn ->
-      assert {:error, %{reason: "API key is not configured"}} == Bugsnag.sync_report("error!")
-    end
+    log =
+      capture_log(fn ->
+        assert {:error, %{reason: "API key is not configured"}} == Bugsnag.sync_report("error!")
+      end)
+
     assert log =~ "api_key is not configured"
   end
 
   test "does not notify bugsnag if you use sync_report and release_stage is not included in the notify_release_stages" do
     old_release_stage = Application.get_env(:bugsnag, :release_stage)
     Application.put_env(:bugsnag, :release_stage, "development")
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
 
     refute Enum.member?(Application.get_env(:bugsnag, :notify_release_stages), "development")
     assert {:ok, :not_sent} = Bugsnag.sync_report(RuntimeError.exception("some_error"))
@@ -88,8 +89,8 @@ defmodule BugsnagTest do
     Application.put_env(:bugsnag, :release_stage, "development")
     Application.put_env(:bugsnag, :notify_release_stages, ["development"])
 
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end
-    on_exit fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
+    on_exit(fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end)
 
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 Code.load_file("test/support/error_server.exs")
 
-ExUnit.start
+ExUnit.start()


### PR DESCRIPTION
Hey,
As mentioned in Issue https://github.com/jarednorman/bugsnag-elixir/issues/59
I've replaced GenEvent by the native erlang :gen_event to avoid Elixir from complaining during compile time.