### PR TITLE
Replace GenEvent with gen_event

### DIFF
--- a/lib/bugsnag/logger.ex
+++ b/lib/bugsnag/logger.ex
@@ -2,9 +2,9 @@ defmodule Bugsnag.Logger do
   require Bugsnag
   require Logger
 
-  use GenEvent
+  @behaviour :gen_event
 
-  def init(_mod, []), do: {:ok, []}
+  def init([]), do: {:ok, []}
 
   def handle_call({:configure, new_keys}, _state) do
     {:ok, :ok, new_keys}


### PR DESCRIPTION
Minimal Fix for Issue #59 

The [Erlang `error_logger` interface's `add_report_handler`](https://github.com/jarednorman/bugsnag-elixir/blob/b477ef05049ed3370f08e4fb1515490d97f0a160/lib/bugsnag.ex#L17) function [requires a `gen_event` interface](http://erlang.org/doc/man/error_logger.html#add_report_handler-1). [Elixir has deprecated `GenEvent`, and for use cases as these recommends using the `gen_event` behaviour](https://hexdocs.pm/elixir/GenEvent.html#content). This change does that.

Confirmed that tests passed.