### PR TITLE
Add `mix format` to CI and format the code

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,16 @@ elixir:
     - 1.3.4
     - 1.4.5
     - 1.5.3
-    - 1.6.3
+    - 1.6.4
 otp_release:
     - 19.3.6
-    - 20.2.4
+    - 20.3.4
 
 matrix:
   exclude:
     - elixir: 1.3.4
-      otp_release: 20.2.4
+      otp_release: 20.3.4
+  include:
+    - elixir: 1.6.4
+      otp_release: 20.3.4
+      script: mix format --check-formatted

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-if Mix.env == :test, do: config :bugsnag, :api_key, "FAKEKEY"
+if Mix.env() == :test, do: config(:bugsnag, :api_key, "FAKEKEY")

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -9,20 +9,21 @@ defmodule Bugsnag do
   @request_headers [{"Content-Type", "application/json"}]
 
   def start(_type, _args) do
-    config = default_config()
-    |> Keyword.merge(Application.get_all_env(:bugsnag))
-    |> Enum.map(fn {k, v} -> {k, eval_config(v)} end)
+    config =
+      default_config()
+      |> Keyword.merge(Application.get_all_env(:bugsnag))
+      |> Enum.map(fn {k, v} -> {k, eval_config(v)} end)
 
-    if (config[:use_logger] |> to_string) == "true" do
+    if to_string(config[:use_logger]) == "true" do
       :error_logger.add_report_handler(Bugsnag.Logger)
     end
 
     # Update Application config with evaluated configuration
     # It's needed for use in Bugsnag.Payload, could be removed
     # by using GenServer instead of this kind of app.
-    Enum.each config, fn {k, v} ->
-      Application.put_env :bugsnag, k, v
-    end
+    Enum.each(config, fn {k, v} ->
+      Application.put_env(:bugsnag, k, v)
+    end)
 
     if !config[:api_key] and should_notify() do
       Logger.warn("Bugsnag api_key is not configured, errors will not be reported")
@@ -41,33 +42,32 @@ defmodule Bugsnag do
   (I.e. this might fail silently)
   """
   def report(exception, options \\ []) do
-    Task.Supervisor.start_child(
-      Bugsnag.TaskSupervisor,
-      __MODULE__,
-      :sync_report,
-      [exception, add_stacktrace(options)]
-    )
+    Task.Supervisor.start_child(Bugsnag.TaskSupervisor, __MODULE__, :sync_report, [
+      exception,
+      add_stacktrace(options)
+    ])
   end
 
   defp add_stacktrace(options) when is_list(options) do
-    Keyword.put_new(options, :stacktrace, System.stacktrace)
+    Keyword.put_new(options, :stacktrace, System.stacktrace())
   end
+
   defp add_stacktrace(options), do: options
 
   @doc "Report the exception and wait for the result. Returns `ok` or `{:error, reason}`."
   def sync_report(exception, options \\ []) do
-    stacktrace = options[:stacktrace] || System.stacktrace
+    stacktrace = options[:stacktrace] || System.stacktrace()
 
     if should_notify() do
       if Application.get_env(:bugsnag, :api_key) do
         Payload.new(exception, stacktrace, options)
-        |> to_json
+        |> Poison.encode!()
         |> send_notification
         |> case do
-          {:ok, %{status_code: 200}}   -> :ok
+          {:ok, %{status_code: 200}} -> :ok
           {:ok, %{status_code: other}} -> {:error, "status_#{other}"}
-          {:error, %{reason: reason}}  -> {:error, reason}
-          _                            -> {:error, :unknown}
+          {:error, %{reason: reason}} -> {:error, reason}
+          _ -> {:error, :unknown}
         end
       else
         Logger.warn("Bugsnag api_key is not configured, error not reported")
@@ -78,30 +78,27 @@ defmodule Bugsnag do
     end
   end
 
-  def to_json(payload) do
-    payload |> Poison.encode!
-  end
-
   defp send_notification(body) do
     HTTPoison.post(notify_url(), body, @request_headers)
   end
 
   def should_notify do
     release_stage = Application.get_env(:bugsnag, :release_stage)
-    notify_release_stages = Application.get_env(:bugsnag, :notify_release_stages)
-    release_stage && is_list(notify_release_stages) && Enum.member?(notify_release_stages, release_stage)
+    notify_stages = Application.get_env(:bugsnag, :notify_release_stages)
+
+    release_stage && is_list(notify_stages) && Enum.member?(notify_stages, release_stage)
   end
 
   defp default_config do
     [
-      api_key:       {:system, "BUGSNAG_API_KEY", nil},
-      endpoint_url:  {:system, "BUGSNAG_ENDPOINT_URL", @notify_url},
-      use_logger:    {:system, "BUGSNAG_USE_LOGGER", true},
+      api_key: {:system, "BUGSNAG_API_KEY", nil},
+      endpoint_url: {:system, "BUGSNAG_ENDPOINT_URL", @notify_url},
+      use_logger: {:system, "BUGSNAG_USE_LOGGER", true},
       release_stage: {:system, "BUGSNAG_RELEASE_STAGE", "production"},
       notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]},
-      hostname:      {:system, "BUGSNAG_HOSTNAME", "unknown"},
-      app_type:      {:system, "BUGSNAG_APP_TYPE", "elixir"},
-      app_version:   {:system, "BUGSNAG_APP_VERSION", nil}
+      hostname: {:system, "BUGSNAG_HOSTNAME", "unknown"},
+      app_type: {:system, "BUGSNAG_APP_TYPE", "elixir"},
+      app_version: {:system, "BUGSNAG_APP_VERSION", nil}
     ]
   end
 

--- a/lib/bugsnag/logger.ex
+++ b/lib/bugsnag/logger.ex
@@ -11,30 +11,32 @@ defmodule Bugsnag.Logger do
   end
 
   def handle_event({_level, gl, _event}, state)
-  when node(gl) != node() do
+      when node(gl) != node() do
     {:ok, state}
   end
 
   def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
-  when is_list(message) do
+      when is_list(message) do
     try do
       error_info = message[:error_info]
 
       case error_info do
         {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
           Bugsnag.report(exception, stacktrace: stacktrace)
+
         {_kind, exception, stacktrace} ->
           Bugsnag.report(exception, stacktrace: stacktrace)
       end
     rescue
       ex ->
-        error_type = Exception.normalize(:error, ex).__struct__
-                      |> Atom.to_string
-                      |> String.replace(~r{\AElixir\.}, "")
+        error_type =
+          Exception.normalize(:error, ex).__struct__
+          |> Atom.to_string()
+          |> String.replace(~r{\AElixir\.}, "")
 
         reason = Exception.message(ex)
 
-        Logger.warn "Unable to notify Bugsnag #{error_type}: #{reason}"
+        Logger.warn("Unable to notify Bugsnag #{error_type}: #{reason}")
     end
 
     {:ok, state}

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -1,8 +1,8 @@
 defmodule Bugsnag.Payload do
   @notifier_info %{
     name: "Bugsnag Elixir",
-    version: Bugsnag.Mixfile.project[:version],
-    url: Bugsnag.Mixfile.project[:package][:links][:github],
+    version: Bugsnag.Mixfile.project()[:version],
+    url: Bugsnag.Mixfile.project()[:package][:links][:github]
   }
 
   defstruct api_key: nil, notifier: @notifier_info, events: nil
@@ -18,44 +18,54 @@ defmodule Bugsnag.Payload do
   end
 
   defp fetch_option(options, key, default \\ nil) do
-    Keyword.get options, key, Application.get_env(:bugsnag, key, default)
+    Keyword.get(options, key, Application.get_env(:bugsnag, key, default))
   end
 
   defp add_event(payload, exception, stacktrace, options) do
     error = Exception.normalize(:error, exception)
 
     event =
-      Map.new
+      Map.new()
       |> add_payload_version
       |> add_exception(error, stacktrace)
       |> add_severity(Keyword.get(options, :severity))
       |> add_context(Keyword.get(options, :context))
       |> add_user(Keyword.get(options, :user))
-      |> add_device(Keyword.get(options, :os_version), fetch_option(options, :hostname, "unknown"))
+      |> add_device(
+        Keyword.get(options, :os_version),
+        fetch_option(options, :hostname, "unknown")
+      )
       |> add_metadata(Keyword.get(options, :metadata))
       |> add_release_stage(fetch_option(options, :release_stage, "production"))
       |> add_notify_release_stages(fetch_option(options, :notify_release_stages, ["production"]))
       |> add_app_type(fetch_option(options, :app_type))
       |> add_app_version(fetch_option(options, :app_version))
 
-    Map.put payload, :events, [event]
+    Map.put(payload, :events, [event])
   end
 
   defp add_exception(event, exception, stacktrace) do
-    Map.put event, :exceptions, [%{
-      errorClass: exception.__struct__,
-      message: Exception.message(exception),
-      stacktrace: format_stacktrace(stacktrace)
-    }]
+    Map.put(event, :exceptions, [
+      %{
+        errorClass: exception.__struct__,
+        message: Exception.message(exception),
+        stacktrace: format_stacktrace(stacktrace)
+      }
+    ])
   end
 
   defp add_payload_version(event), do: Map.put(event, :payloadVersion, "2")
 
-  defp add_severity(event, severity) when severity in ~w(error warning info), do: Map.put(event, :severity, severity)
+  defp add_severity(event, severity) when severity in ~w(error warning info),
+    do: Map.put(event, :severity, severity)
+
   defp add_severity(event, _), do: Map.put(event, :severity, "error")
 
-  defp add_release_stage(event, release_stage), do: Map.put(event, :app, %{releaseStage: release_stage})
-  defp add_notify_release_stages(event, notify_release_stages), do: Map.put(event, :notifyReleaseStages, notify_release_stages)
+  defp add_release_stage(event, release_stage),
+    do: Map.put(event, :app, %{releaseStage: release_stage})
+
+  defp add_notify_release_stages(event, notify_release_stages),
+    do: Map.put(event, :notifyReleaseStages, notify_release_stages)
 
   defp add_context(event, nil), do: event
   defp add_context(event, context), do: Map.put(event, :context, context)
@@ -70,8 +80,8 @@ defmodule Bugsnag.Payload do
       |> Map.merge(if hostname, do: %{hostname: hostname}, else: %{})
 
     if Enum.empty?(device),
-    do:   event,
-    else: Map.put(event, :device, device)
+      do: event,
+      else: Map.put(event, :device, device)
   end
 
   defp add_app_type(event, type) do
@@ -81,6 +91,7 @@ defmodule Bugsnag.Payload do
   end
 
   defp add_app_version(event, nil), do: event
+
   defp add_app_version(event, version) do
     event
     |> Map.put_new(:app, %{})
@@ -91,15 +102,17 @@ defmodule Bugsnag.Payload do
   defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)
 
   defp format_stacktrace(stacktrace) do
-    Enum.map stacktrace, fn
-      ({ module, function, args, [] }) ->
+    Enum.map(stacktrace, fn
+      {module, function, args, []} ->
         %{
           file: "unknown",
           lineNumber: 0,
           method: Exception.format_mfa(module, function, args)
         }
-      ({ module, function, args, [file: file, line: line_number] }) ->
-        file = to_string file
+
+      {module, function, args, [file: file, line: line_number]} ->
+        file = to_string(file)
+
         %{
           file: file,
           lineNumber: line_number,
@@ -107,17 +120,17 @@ defmodule Bugsnag.Payload do
           method: Exception.format_mfa(module, function, args),
           code: get_file_contents(file, line_number)
         }
-    end
+    end)
   end
 
   defp get_file_contents(file, line_number) do
-    file = File.cwd! |> Path.join(file)
+    file = File.cwd!() |> Path.join(file)
 
     if File.exists?(file) do
       file
-      |> File.stream!
-      |> Stream.with_index
-      |> Stream.map(fn({line, index}) -> {to_string(index + 1), line} end)
+      |> File.stream!()
+      |> Stream.with_index()
+      |> Stream.map(fn {line, index} -> {to_string(index + 1), line} end)
       |> Enum.slice(if(line_number - 4 > 0, do: line_number - 4, else: 0), 7)
       |> Enum.into(%{})
     end

--- a/mix.exs
+++ b/mix.exs
@@ -2,32 +2,35 @@ defmodule Bugsnag.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :bugsnag,
-     version: "1.5.0",
-     elixir: "~> 1.3",
-     package: package(),
-     description: """
-       An Elixir interface to the Bugsnag API
-     """,
-     deps: deps()]
+    [
+      app: :bugsnag,
+      version: "1.5.0",
+      elixir: "~> 1.3",
+      package: package(),
+      description: "An Elixir interface to the Bugsnag API.",
+      deps: deps()
+    ]
   end
 
   def package do
-    [contributors: ["Jared Norman", "Andrew Harvey"],
-     maintainers: ["Andrew Harvey"],
-     licenses: ["MIT"],
-     links: %{github: "https://github.com/jarednorman/bugsnag-elixir"}]
+    [
+      contributors: ["Jared Norman", "Andrew Harvey"],
+      maintainers: ["Andrew Harvey"],
+      licenses: ["MIT"],
+      links: %{github: "https://github.com/jarednorman/bugsnag-elixir"}
+    ]
   end
 
   def application do
-    [applications: [:httpoison, :logger],
-     mod: {Bugsnag, []}]
+    [applications: [:httpoison, :logger], mod: {Bugsnag, []}]
   end
 
   defp deps do
-    [{:httpoison, "~> 1.0"},
-     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
-     {:ex_doc, ">= 0.0.0", only: :dev},
-     {:meck, "~> 0.8.3", only: :test}]
+    [
+      {:httpoison, "~> 1.0"},
+      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:meck, "~> 0.8.3", only: :test}
+    ]
   end
 end

--- a/test/bugsnag/logger_test.exs
+++ b/test/bugsnag/logger_test.exs
@@ -8,37 +8,39 @@ defmodule Bugsnag.LoggerTest do
   setup_all do
     :error_logger.add_report_handler(Bugsnag.Logger)
 
-    on_exit fn ->
+    on_exit(fn ->
       :error_logger.delete_report_handler(Bugsnag.Logger)
-    end
+    end)
 
     Application.put_env(:bugsnag, :release_stage, "test")
     Application.put_env(:bugsnag, :notify_release_stages, ["test"])
 
-    on_exit fn -> Application.delete_env(:bugsnag, :release_stage) end
-    on_exit fn -> Application.delete_env(:bugsnag, :notify_release_stages) end
+    on_exit(fn -> Application.delete_env(:bugsnag, :release_stage) end)
+    on_exit(fn -> Application.delete_env(:bugsnag, :notify_release_stages) end)
   end
 
   test "logging a crash" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    :proc_lib.spawn fn ->
+    :proc_lib.spawn(fn ->
       raise RuntimeError, "Oops"
-    end
-    :timer.sleep 250
+    end)
+
+    :timer.sleep(250)
 
     assert :meck.called(HTTP, :post, [:_, :_, :_])
     :meck.unload(HTTP)
   end
 
   test "crashes do not cause recursive logging" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Error{reason: 500} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Error{reason: 500} end)
 
-    log_msg = capture_log fn ->
-      error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
-      :error_logger.error_report(error_report)
-      :timer.sleep 250
-    end
+    log_msg =
+      capture_log(fn ->
+        error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
+        :error_logger.error_report(error_report)
+        :timer.sleep(250)
+      end)
 
     assert log_msg =~ "[[error_info: {:error, %RuntimeError{message: \"Oops\"}, []}], []]"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
@@ -49,39 +51,42 @@ defmodule Bugsnag.LoggerTest do
   test "log levels lower than :error_report are ignored" do
     message_types = [:info_msg, :info_report, :warning_msg, :error_msg]
 
-    Enum.each message_types, fn(type) ->
-      log_msg = capture_log fn ->
-        :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
-        apply(:error_logger, type, ["Ignore me"])
-        :timer.sleep 250
-        refute :meck.called(HTTP, :post, [:_, :_, :_])
-      end
+    Enum.each(message_types, fn type ->
+      log_msg =
+        capture_log(fn ->
+          :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
+          apply(:error_logger, type, ["Ignore me"])
+          :timer.sleep(250)
+          refute :meck.called(HTTP, :post, [:_, :_, :_])
+        end)
 
       assert log_msg =~ "Ignore me"
-    end
+    end)
 
     :meck.unload(HTTP)
   end
 
   test "logging exceptions from special processes" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    :proc_lib.spawn fn ->
+    :proc_lib.spawn(fn ->
       Float.parse("12.345e308")
-    end
-    :timer.sleep 250
+    end)
+
+    :timer.sleep(250)
 
     assert :meck.called(HTTP, :post, [:_, :_, :_])
     :meck.unload(HTTP)
   end
 
   test "logging exceptions from Tasks" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    log_msg = capture_log fn ->
-      Task.start fn -> Float.parse("12.345e308") end
-      :timer.sleep 250
-    end
+    log_msg =
+      capture_log(fn ->
+        Task.start(fn -> Float.parse("12.345e308") end)
+        :timer.sleep(250)
+      end)
 
     assert log_msg =~ "(ArgumentError) argument error"
     assert :meck.called(HTTP, :post, [:_, :_, :_])
@@ -90,14 +95,15 @@ defmodule Bugsnag.LoggerTest do
   end
 
   test "logging exceptions from GenServers" do
-    :meck.expect(HTTP, :post, fn(_ex, _c, _s) -> %HTTP.Response{} end)
+    :meck.expect(HTTP, :post, fn _ex, _c, _s -> %HTTP.Response{} end)
 
-    {:ok, pid} = ErrorServer.start
+    {:ok, pid} = ErrorServer.start()
 
-    log_msg = capture_log fn ->
-      GenServer.cast(pid, :fail)
-      :timer.sleep 250
-    end
+    log_msg =
+      capture_log(fn ->
+        GenServer.cast(pid, :fail)
+        :timer.sleep(250)
+      end)
 
     # We assert either of these log messages because the log changed between elixir
     # versions. It feels like we shouldn't need to assert on the log message but...

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -8,12 +8,12 @@ defmodule Bugsnag.PayloadTest do
       # You've been warned!
       Harbour.cats(3)
     rescue
-      exception -> [exception, System.stacktrace]
+      exception -> [exception, System.stacktrace()]
     end
   end
 
   def get_payload(options \\ []) do
-    apply Payload, :new, List.insert_at(get_problem(), -1, options)
+    apply(Payload, :new, List.insert_at(get_problem(), -1, options))
   end
 
   def get_event(options \\ []) do
@@ -44,31 +44,51 @@ defmodule Bugsnag.PayloadTest do
       try do
         Enum.join(3, 'million')
       rescue
-        exception -> {exception, System.stacktrace}
+        exception -> {exception, System.stacktrace()}
       end
 
-    %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} = Payload.new(exception, stacktrace, [])
-    assert [%{file: "lib/enum.ex", lineNumber: _, method: _},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: ~s(Bugsnag.PayloadTest."test it generates correct stacktraces"/1)}
-            | _] = stacktrace
+    %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =
+      Payload.new(exception, stacktrace, [])
+
+    [
+      %{file: "lib/enum.ex", lineNumber: _, method: _},
+      %{
+        file: "test/bugsnag/payload_test.exs",
+        lineNumber: _,
+        method: ~s(Bugsnag.PayloadTest."test it generates correct stacktraces"/1)
+      }
+      | _
+    ] = stacktrace
   end
 
   test "it generates correct stacktraces when the current file was a script" do
-    assert [%{file: "unknown", lineNumber: 0, method: _},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: 9, method: "Bugsnag.PayloadTest.get_problem/0"},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _} | _] = get_exception().stacktrace
+    [
+      %{file: "unknown", lineNumber: 0, method: _},
+      %{
+        file: "test/bugsnag/payload_test.exs",
+        lineNumber: 9,
+        method: "Bugsnag.PayloadTest.get_problem/0"
+      },
+      %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _} | _
+    ] = get_exception().stacktrace
   end
 
   # NOTE: Regression test
   test "it generates correct stacktraces when the method arguments are in place of arity" do
-    {exception, stacktrace} = try do
-      Fart.poo(:butts, 1, "foo\n")
-    rescue
-      exception -> {exception, System.stacktrace}
-    end
-    %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} = Payload.new(exception, stacktrace, [])
-    assert [%{file: "unknown", lineNumber: 0, method: "Fart.poo(:butts, 1, \"foo\\n\")"},
-            %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _, code: _} | _] = stacktrace
+    {exception, stacktrace} =
+      try do
+        Fart.poo(:butts, 1, "foo\n")
+      rescue
+        exception -> {exception, System.stacktrace()}
+      end
+
+    %{events: [%{exceptions: [%{stacktrace: stacktrace}]}]} =
+      Payload.new(exception, stacktrace, [])
+
+    [
+      %{file: "unknown", lineNumber: 0, method: "Fart.poo(:butts, 1, \"foo\\n\")"},
+      %{file: "test/bugsnag/payload_test.exs", lineNumber: _, method: _, code: _} | _
+    ] = stacktrace
   end
 
   test "it reports the error class" do
@@ -88,16 +108,16 @@ defmodule Bugsnag.PayloadTest do
 
   test "it reports the release stage" do
     assert "production" == get_event().app.releaseStage
-    assert "staging"    == get_event(release_stage: "staging").app.releaseStage
-    assert "qa"         == get_event(release_stage: "qa").app.releaseStage
-    assert ""           == get_event(release_stage: "").app.releaseStage
+    assert "staging" == get_event(release_stage: "staging").app.releaseStage
+    assert "qa" == get_event(release_stage: "qa").app.releaseStage
+    assert "" == get_event(release_stage: "").app.releaseStage
   end
 
   test "it reports the notify release stages" do
     assert ["production"] == get_event().notifyReleaseStages
-    assert ["staging"]    == get_event(notify_release_stages: ["staging"]).notifyReleaseStages
-    assert ["qa"]         == get_event(notify_release_stages: ["qa"]).notifyReleaseStages
-    assert [""]           == get_event(notify_release_stages: [""]).notifyReleaseStages
+    assert ["staging"] == get_event(notify_release_stages: ["staging"]).notifyReleaseStages
+    assert ["qa"] == get_event(notify_release_stages: ["qa"]).notifyReleaseStages
+    assert [""] == get_event(notify_release_stages: [""]).notifyReleaseStages
   end
 
   test "it reports the payload version" do
@@ -115,7 +135,7 @@ defmodule Bugsnag.PayloadTest do
   test "is sets the device info if given" do
     evt = get_event(os_version: "some-version 1.0", hostname: "some-host")
     assert "some-version 1.0" == evt.device.osVersion
-    assert "some-host"        == evt.device.hostname
+    assert "some-host" == evt.device.hostname
   end
 
   test "it reports the hostname in the application's config if specified" do
@@ -137,8 +157,10 @@ defmodule Bugsnag.PayloadTest do
   end
 
   test "it reports the notifier" do
-    assert %{name: "Bugsnag Elixir",
-             url: "https://github.com/jarednorman/bugsnag-elixir",
-             version: _} = get_payload().notifier
+    %{
+      name: "Bugsnag Elixir",
+      url: "https://github.com/jarednorman/bugsnag-elixir",
+      version: _
+    } = get_payload().notifier
   end
 end

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -4,15 +4,15 @@ defmodule BugsnagTest do
   import ExUnit.CaptureLog
 
   test "it doesn't raise errors if you report garbage" do
-    capture_log fn ->
+    capture_log(fn ->
       Bugsnag.report(Enum, %{ignore: :this_error_in_test})
-    end
+    end)
   end
 
   test "it returns proper results if you use sync_report" do
     old_release_stage = Application.get_env(:bugsnag, :release_stage)
     Application.put_env(:bugsnag, :release_stage, "production")
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
 
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
@@ -25,11 +25,6 @@ defmodule BugsnagTest do
     end
   end
 
-  test "it can encode json" do
-    assert Bugsnag.to_json(%{foo: 3, bar: "baz"}) ==
-      "{\"foo\":3,\"bar\":\"baz\"}"
-  end
-
   test "it puts application env values on startup" do
     assert Application.get_env(:bugsnag, :release_stage) == "production"
     assert Application.get_env(:bugsnag, :api_key) == "FAKEKEY"
@@ -40,7 +35,7 @@ defmodule BugsnagTest do
   test "it warns if no api_key is configured" do
     {:ok, old_key} = Application.fetch_env(:bugsnag, :api_key)
     Application.delete_env(:bugsnag, :api_key)
-    on_exit fn -> Application.put_env(:bugsnag, :api_key, old_key) end
+    on_exit(fn -> Application.put_env(:bugsnag, :api_key, old_key) end)
 
     assert capture_log(fn -> Bugsnag.start(:temporary, %{}) end) =~ "api_key is not configured"
   end
@@ -48,14 +43,14 @@ defmodule BugsnagTest do
   test "it doesn't warn about api_key if the current release stage is not a notifying one" do
     {:ok, old_stage} = Application.fetch_env(:bugsnag, :release_stage)
     Application.put_env(:bugsnag, :release_stage, "development")
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_stage) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_stage) end)
 
     assert capture_log(fn -> Bugsnag.start(:temporary, %{}) end) == ""
   end
 
   test "it should not explode with logger unset" do
     Application.put_env(:bugsnag, :use_logger, nil)
-    on_exit fn -> Application.put_env(:bugsnag, :use_logger, true) end
+    on_exit(fn -> Application.put_env(:bugsnag, :use_logger, true) end)
 
     Bugsnag.start(:temporary, %{})
     assert Application.get_env(:bugsnag, :use_logger) == nil
@@ -64,18 +59,20 @@ defmodule BugsnagTest do
   test "warns and returns an error when sending a report with no API key configured" do
     {:ok, old_key} = Application.fetch_env(:bugsnag, :api_key)
     Application.delete_env(:bugsnag, :api_key)
-    on_exit fn -> Application.put_env(:bugsnag, :api_key, old_key) end
+    on_exit(fn -> Application.put_env(:bugsnag, :api_key, old_key) end)
 
-    log = capture_log fn ->
-      assert {:error, %{reason: "API key is not configured"}} == Bugsnag.sync_report("error!")
-    end
+    log =
+      capture_log(fn ->
+        assert {:error, %{reason: "API key is not configured"}} == Bugsnag.sync_report("error!")
+      end)
+
     assert log =~ "api_key is not configured"
   end
 
   test "does not notify bugsnag if you use sync_report and release_stage is not included in the notify_release_stages" do
     old_release_stage = Application.get_env(:bugsnag, :release_stage)
     Application.put_env(:bugsnag, :release_stage, "development")
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
 
     refute Enum.member?(Application.get_env(:bugsnag, :notify_release_stages), "development")
     assert {:ok, :not_sent} = Bugsnag.sync_report(RuntimeError.exception("some_error"))
@@ -88,8 +85,8 @@ defmodule BugsnagTest do
     Application.put_env(:bugsnag, :release_stage, "development")
     Application.put_env(:bugsnag, :notify_release_stages, ["development"])
 
-    on_exit fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end
-    on_exit fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end
+    on_exit(fn -> Application.put_env(:bugsnag, :release_stage, old_release_stage) end)
+    on_exit(fn -> Application.put_env(:bugsnag, :notify_release_stages, old_notify_stages) end)
 
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -19,7 +19,7 @@ defmodule BugsnagTest do
 
   test "it handles real errors" do
     try do
-      :foo = :bar
+      raise "an exception"
     rescue
       exception -> Bugsnag.report(exception)
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 Code.load_file("test/support/error_server.exs")
 
-ExUnit.start
+ExUnit.start()


### PR DESCRIPTION
With apologies for the one-time commit noise... this will cause CI to fail if any code is not formatted, so the `mix format` style will be enforced from here on.