### PR TITLE
Configurable in_project classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ config :bugsnag, use_logger: true
 
 # Override the default bugsnag endpoint url
 config :bugsnag, endpoint_url: "https://notify.bugsnag.com"
+
+# Tell bugsnag to mark stack frames containing "myproj" as in-project
+config :bugsnag, in_project: "myproj"
+
+# Tell bugsnag to mark stack frames starting with "lib/myproj" as in-project
+config :bugsnag, in_project: ~r/lib\/myproj/
+
+# Tell bugsnag to call a function per stack frame to determine in-project
+defmodule MyProject
+  def in_project?({module, fun, args, line}, addl_mods) do
+    module in addl_mods or line =~ r/^lib\/myproj/
+  end
+end
+...
+config :bugsnag, in_project: {MyProject, :in_project?, [AddlMod1, AddlMod2]}
 ```
 
 ## Usage
@@ -49,6 +64,7 @@ You can use environment variables in order to set up all options. You can set de
 - `BUGSNAG_HOSTNAME`
 - `BUGSNAG_APP_TYPE`
 - `BUGSNAG_APP_VERSION`
+- `BUGSNAG_IN_PROJECT_REGEX`
 
 Or you can define from which env vars it should be loaded, eg:
 
@@ -61,9 +77,10 @@ config :bugsnag, :use_logger,     {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :hostname,       {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :app_type,       {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :app_version,    {:system, "YOUR_ENV_VAR" [, optional_default]}
+config :bugsnag, :in_project,    {:system, "YOUR_ENV_VAR" [, optional_default]}
 ```
 
-Ofcourse you can use regular values as in Installation guide.
+Of course you can use regular values as in Installation guide.
 
 ### Manual reporting
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -98,8 +98,13 @@ defmodule Bugsnag do
       notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]},
       hostname: {:system, "BUGSNAG_HOSTNAME", "unknown"},
       app_type: {:system, "BUGSNAG_APP_TYPE", "elixir"},
-      app_version: {:system, "BUGSNAG_APP_VERSION", nil}
+      app_version: {:system, "BUGSNAG_APP_VERSION", nil},
+      in_project: {__MODULE__, :in_project?}
     ]
+  end
+
+  def in_project?(file) do
+    Regex.match?(~r/^(lib|web)/, file)
   end
 
   defp eval_config({:system, env_var, default}) do

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -99,14 +99,8 @@ defmodule Bugsnag do
       hostname: {:system, "BUGSNAG_HOSTNAME", "unknown"},
       app_type: {:system, "BUGSNAG_APP_TYPE", "elixir"},
       app_version: {:system, "BUGSNAG_APP_VERSION", nil},
-      in_project: {__MODULE__, :file_matches?, [~r/^(lib|web)/]}
+      in_project: {:system, "BUGSNAG_IN_PROJECT_REGEX", nil},
     ]
-  end
-
-  def file_matches?({_module, _fun, _args, file}, patterns) do
-    Enum.any?(patterns, fn pattern ->
-      String.match?(file, pattern)
-    end)
   end
 
   defp eval_config({:system, env_var, default}) do

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -104,7 +104,7 @@ defmodule Bugsnag do
   end
 
   def file_matches?({_module, _fun, _args, file}, patterns) do
-    Enum.any?(patterns, fn (pattern) ->
+    Enum.any?(patterns, fn pattern ->
       String.match?(file, pattern)
     end)
   end

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -99,12 +99,14 @@ defmodule Bugsnag do
       hostname: {:system, "BUGSNAG_HOSTNAME", "unknown"},
       app_type: {:system, "BUGSNAG_APP_TYPE", "elixir"},
       app_version: {:system, "BUGSNAG_APP_VERSION", nil},
-      in_project: {__MODULE__, :in_project?}
+      in_project: {__MODULE__, :file_matches?, [~r/^(lib|web)/]}
     ]
   end
 
-  def in_project?(file) do
-    Regex.match?(~r/^(lib|web)/, file)
+  def file_matches?({_module, _fun, _args, file}, patterns) do
+    Enum.any?(patterns, fn (pattern) ->
+      String.match?(file, pattern)
+    end)
   end
 
   defp eval_config({:system, env_var, default}) do

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -102,6 +102,7 @@ defmodule Bugsnag.Payload do
   defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)
 
   defp format_stacktrace(stacktrace) do
+    {in_project_mod, in_project_fun} = Application.get_env(:bugsnag, :in_project)
     Enum.map(stacktrace, fn
       {module, function, args, []} ->
         %{
@@ -116,7 +117,7 @@ defmodule Bugsnag.Payload do
         %{
           file: file,
           lineNumber: line_number,
-          inProject: Regex.match?(~r/^(lib|web)/, file),
+          inProject: apply(in_project_mod, in_project_fun, [file]),
           method: Exception.format_mfa(module, function, args),
           code: get_file_contents(file, line_number)
         }

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -102,7 +102,9 @@ defmodule Bugsnag.Payload do
   defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)
 
   defp format_stacktrace(stacktrace, options) do
-    {ip_mod, ip_fun, ip_state} = fetch_option(options, :in_project, {Bugsnag, :file_matches?, [~r/^(lib|web)/]})
+    {ip_mod, ip_fun, ip_state} =
+      fetch_option(options, :in_project, {Bugsnag, :file_matches?, [~r/^(lib|web)/]})
+
     Enum.map(stacktrace, fn
       {module, function, args, []} ->
         %{


### PR DESCRIPTION
This change addresses #73 by introducing a configurable predicate with the preexisting system being the default. The inclusion of an additional parameter should make it easy enough for people to change to an easy sane default, but expressive enough for a use case like our project, which has multiple internal dependencies which we also wish to alert on. (And some we don't.)

This PR still has the following problems:
- [ ] No tests
- [x] No docs
- [x] property name/UI isn't great (maybe split it into predicate and option or something?)
- [x] Where should `file_matches?/2` go? `Bugsnag` seems like the wrong place.

I'm interested in hearing thoughts on this approach.