### PR TITLE
Enable marking stack frames as "in-project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ config :bugsnag, use_logger: true
 
 # Override the default bugsnag endpoint url
 config :bugsnag, endpoint_url: "https://notify.bugsnag.com"
+
+# Mark stack frames containing "myproj" as in-project
+config :bugsnag, in_project: "myproj"
+
+# ...or mark stack frames starting with "lib/myproj" as in-project
+config :bugsnag, in_project: ~r(^lib/myproj)
+
+# ...or call a function per stack frame that returns whether it is in-project
+config :bugsnag, in_project: {MyProject, :in_project?, []}
+
+defmodule MyProject
+  def in_project?({module, fun, args, line}) do
+    module in [SomeMod1, SomeMod2] or line =~ ~r(^lib/myproj)
+  end
+end
 ```
 
 ## Usage
@@ -49,6 +64,7 @@ You can use environment variables in order to set up all options. You can set de
 - `BUGSNAG_HOSTNAME`
 - `BUGSNAG_APP_TYPE`
 - `BUGSNAG_APP_VERSION`
+- `BUGSNAG_IN_PROJECT`
 
 Or you can define from which env vars it should be loaded, eg:
 
@@ -56,14 +72,15 @@ Or you can define from which env vars it should be loaded, eg:
 config :bugsnag, :api_key,        {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :endpoint_url,   {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :release_stage,  {:system, "YOUR_ENV_VAR" [, optional_default]}
-config :bugsnag, :notify_release_stages,  {:system, "YOUR_ENV_VAR" [, optional_default]}
+config :bugsnag, :notify_release_stages, {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :use_logger,     {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :hostname,       {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :app_type,       {:system, "YOUR_ENV_VAR" [, optional_default]}
 config :bugsnag, :app_version,    {:system, "YOUR_ENV_VAR" [, optional_default]}
+config :bugsnag, :in_project,     {:system, "YOUR_ENV_VAR" [, optional_default]}
 ```
 
-Ofcourse you can use regular values as in Installation guide.
+Of course you can use regular values as in Installation guide.
 
 ### Manual reporting
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -98,7 +98,8 @@ defmodule Bugsnag do
       notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]},
       hostname: {:system, "BUGSNAG_HOSTNAME", "unknown"},
       app_type: {:system, "BUGSNAG_APP_TYPE", "elixir"},
-      app_version: {:system, "BUGSNAG_APP_VERSION", nil}
+      app_version: {:system, "BUGSNAG_APP_VERSION", nil},
+      in_project: {:system, "BUGSNAG_IN_PROJECT", nil}
     ]
   end
 

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -27,7 +27,7 @@ defmodule Bugsnag.Payload do
     event =
       Map.new()
       |> add_payload_version
-      |> add_exception(error, stacktrace)
+      |> add_exception(error, stacktrace, options)
       |> add_severity(Keyword.get(options, :severity))
       |> add_context(Keyword.get(options, :context))
       |> add_user(Keyword.get(options, :user))
@@ -44,12 +44,12 @@ defmodule Bugsnag.Payload do
     Map.put(payload, :events, [event])
   end
 
-  defp add_exception(event, exception, stacktrace) do
+  defp add_exception(event, exception, stacktrace, options) do
     Map.put(event, :exceptions, [
       %{
         errorClass: exception.__struct__,
         message: Exception.message(exception),
-        stacktrace: format_stacktrace(stacktrace)
+        stacktrace: format_stacktrace(stacktrace, options)
       }
     ])
   end
@@ -101,12 +101,15 @@ defmodule Bugsnag.Payload do
   defp add_metadata(event, nil), do: event
   defp add_metadata(event, metadata), do: Map.put(event, :metaData, metadata)
 
-  defp format_stacktrace(stacktrace) do
+  defp format_stacktrace(stacktrace, options) do
+    in_project_fn = get_in_project_fn(options)
+
     Enum.map(stacktrace, fn
       {module, function, args, []} ->
         %{
           file: "unknown",
           lineNumber: 0,
+          inProject: false,
           method: Exception.format_mfa(module, function, args)
         }
 
@@ -116,11 +119,30 @@ defmodule Bugsnag.Payload do
         %{
           file: file,
           lineNumber: line_number,
-          inProject: Regex.match?(~r/^(lib|web)/, file),
+          inProject: in_project_fn.({module, function, args, file}),
           method: Exception.format_mfa(module, function, args),
           code: get_file_contents(file, line_number)
         }
     end)
+  end
+
+  defp get_in_project_fn(options) do
+    case fetch_option(options, :in_project, nil) do
+      func when is_function(func) ->
+        func
+
+      {mod, fun, args} ->
+        fn stack_frame -> apply(mod, fun, [stack_frame | args]) end
+
+      %Regex{} = re ->
+        fn {_m, _f, _a, file} -> Regex.match?(re, file) end
+
+      str when is_binary(str) ->
+        fn {_m, _f, _a, file} -> String.contains?(file, str) end
+
+      _other ->
+        fn _ -> false end
+    end
   end
 
   defp get_file_contents(file, line_number) do


### PR DESCRIPTION
Since #74 has not seen activity in some weeks, I built on the great initial implementation by @shantiii and added some tests. Looking forward to fixing the "everything is in-project" issue since the faulty grouping has been bugging us (pun intended?).