### PR TITLE
Add support for atoms in severity option

### DIFF
--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -59,6 +59,9 @@ defmodule Bugsnag.Payload do
   defp add_severity(event, severity) when severity in ~w(error warning info),
     do: Map.put(event, :severity, severity)
 
+  defp add_severity(event, severity) when severity in ~w(error warning info)a,
+    do: Map.put(event, :severity, "#{severity}")
+
   defp add_severity(event, _), do: Map.put(event, :severity, "error")
 
   defp add_release_stage(event, release_stage),

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -153,6 +153,10 @@ defmodule Bugsnag.PayloadTest do
     assert "info" == get_event(severity: "info").severity
     assert "warning" == get_event(severity: "warning").severity
     assert "error" == get_event(severity: "").severity
+    assert "error" == get_event(severity: :error).severity
+    assert "info" == get_event(severity: :info).severity
+    assert "warning" == get_event(severity: :warning).severity
+    assert "error" == get_event(severity: :another).severity
   end
 
   test "it reports the release stage" do


### PR DESCRIPTION
In some case people might use atoms in the severity option.