### PR TITLE
Configurable log message filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Capture exceptions and send them to the [Bugsnag](https://www.bugsnag.com/) API!
   - [`in_project`](#in_project)
   - [`endpoint_url`](#endpoint_url)
   - [`use_logger`](#use_logger)
+  - [`exception_filter`](#exception_filter)
 - [Usage](#usage)
   - [Manual Reporting](#manual-reporting)
   - [Reporting Options](#reporting-options)
@@ -181,6 +182,20 @@ Allows sending reports to a different URL (e.g. if using Bugsnag On-premise).
 Controls whether the default Erlang `:error_logger` handler is added on
 application startup. This will automatically report most process crashes.
 
+### `exception_filter`
+
+**Default:** `nil`
+
+Optional module that allows filtering of log messages. For example
+```Elixir
+defmodule MyApp.ExceptionFilter do
+  def should_notify({{%{plug_status: resp_status},_},_}, _stacktrace) when is_integer(resp_status) do
+    #structure used by cowboy 2.0
+    resp_status < 400 or resp_status >= 500
+  end
+  def should_notify(_e, _s), do: true
+end
+```
 
 ## Usage
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -136,7 +136,7 @@ defmodule Bugsnag do
     rescue
       _ ->
         # Swallowing error in order to avoid exception loops
-       true
+        true
     end
   end
 end

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -28,7 +28,7 @@ defmodule Bugsnag do
       Application.put_env(:bugsnag, k, v)
     end)
 
-    if !config[:api_key] and should_notify() do
+    if !config[:api_key] and reported_stage() do
       Logger.warn("Bugsnag api_key is not configured, errors will not be reported")
     end
 
@@ -59,7 +59,7 @@ defmodule Bugsnag do
   def sync_report(exception, options \\ []) do
     stacktrace = options[:stacktrace] || System.stacktrace()
 
-    if should_notify() do
+    if should_notify(exception, stacktrace) do
       if Application.get_env(:bugsnag, :api_key) do
         Payload.new(exception, stacktrace, options)
         |> Poison.encode!()
@@ -83,11 +83,14 @@ defmodule Bugsnag do
     HTTPoison.post(notify_url(), body, @request_headers)
   end
 
-  def should_notify do
+  defp reported_stage() do
     release_stage = Application.get_env(:bugsnag, :release_stage)
     notify_stages = Application.get_env(:bugsnag, :notify_release_stages)
-
     release_stage && is_list(notify_stages) && Enum.member?(notify_stages, release_stage)
+  end
+
+  def should_notify(exception, stacktrace) do
+    reported_stage() && test_filter(exception_filter(), exception, stacktrace)
   end
 
   defp default_config do
@@ -119,5 +122,21 @@ defmodule Bugsnag do
 
   defp notify_url do
     Application.get_env(:bugsnag, :endpoint_url, @notify_url)
+  end
+
+  defp exception_filter() do
+    Application.get_env(:bugsnag, :exception_filter)
+  end
+
+  defp test_filter(nil, _, _), do: true
+
+  defp test_filter(module, exception, stacktrace) do
+    try do
+      module.should_notify(exception, stacktrace)
+    rescue
+      _ ->
+        # Swallowing error in order to avoid exception loops
+       true
+    end
   end
 end

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -12,7 +12,7 @@ defmodule BugsnagTest do
   end
 
   defmodule FilterCrash do
-    def should_notify(_e, _s), do: raise "boom"
+    def should_notify(_e, _s), do: raise("boom")
   end
 
   test "it doesn't raise errors if you report garbage" do


### PR DESCRIPTION
After upgrading to phoenix 1.4 bugsnag was filled with 404 because they are reported to logger as errors. This change adds a hook that will allow end users to filter whatever logs they don't want to be reported.