### PR TITLE
Fix Jason producing encoded JSON payloads without the `apiKey` field; make JSON library configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Capture exceptions and send them to the [Bugsnag](https://www.bugsnag.com/) API!
   - [`hostname`](#hostname)
   - [`app_type`](#app_type)
   - [`app_version`](#app_version)
+  - [`sanitizer`](#sanitizer)
   - [`in_project`](#in_project)
   - [`endpoint_url`](#endpoint_url)
   - [`use_logger`](#use_logger)
   - [`exception_filter`](#exception_filter)
+  - [`json_library`](#json_library)
 - [Usage](#usage)
   - [Manual Reporting](#manual-reporting)
   - [Reporting Options](#reporting-options)
@@ -33,7 +35,12 @@ Capture exceptions and send them to the [Bugsnag](https://www.bugsnag.com/) API!
 ```elixir
 # mix.exs
 defp deps do
-  [{:bugsnag, "~> 1.7.0"}]
+  [
+    {:bugsnag, "~> 1.7.0"},
+    # pick ONE of these JSON encoding libraries:
+    {:jason, "~> 1.0"},
+    {:posion, "~> 3.0"}
+  ]
 end
 ```
 
@@ -127,7 +134,7 @@ Sets the default application type for reported errors.
 
 Sets the default application version for reported errors.
 
-### Sanitizer
+### `sanitizer`
 
 **Default:** `nil`
 
@@ -226,6 +233,12 @@ defmodule MyApp.ExceptionFilter do
   def should_notify(_e, _s), do: true
 end
 ```
+
+### `json_library`
+
+**Default:** `Jason`
+
+The JSON encoding library.
 
 ## Usage
 

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -51,6 +51,8 @@ defmodule Bugsnag do
     ])
   end
 
+  def json_library(), do: Application.get_env(:bugsnag, :json_library, Jason)
+
   defp add_stacktrace(options) do
     if options[:stacktrace], do: options, else: put_in(options[:stacktrace], System.stacktrace())
   end

--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -61,8 +61,9 @@ defmodule Bugsnag do
 
     if should_notify(exception, stacktrace) do
       if Application.get_env(:bugsnag, :api_key) do
-        Payload.new(exception, stacktrace, options)
-        |> Jason.encode!()
+        exception
+        |> Payload.new(stacktrace, options)
+        |> Payload.encode()
         |> send_notification
         |> case do
           {:ok, %{status_code: 200}} -> :ok

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -7,7 +7,6 @@ defmodule Bugsnag.Payload do
     url: Bugsnag.Mixfile.project()[:package][:links][:github]
   }
 
-  @derive Jason.Encoder
   defstruct api_key: nil, notifier: @notifier_info, events: nil
 
   def new(exception, stacktrace, options) when is_map(options) do
@@ -15,9 +14,13 @@ defmodule Bugsnag.Payload do
   end
 
   def new(exception, stacktrace, options) do
-    %__MODULE__{}
-    |> Map.put(:apiKey, fetch_option(options, :api_key))
+    __MODULE__
+    |> struct(api_key: fetch_option(options, :api_key))
     |> add_event(exception, stacktrace, options)
+  end
+
+  def encode(%__MODULE__{api_key: api_key, notifier: notifier, events: events}) do
+    Jason.encode!(%{apiKey: api_key, notifier: notifier, events: events})
   end
 
   defp fetch_option(options, key, default \\ nil) do

--- a/lib/bugsnag/payload.ex
+++ b/lib/bugsnag/payload.ex
@@ -20,7 +20,7 @@ defmodule Bugsnag.Payload do
   end
 
   def encode(%__MODULE__{api_key: api_key, notifier: notifier, events: events}) do
-    Jason.encode!(%{apiKey: api_key, notifier: notifier, events: events})
+    Bugsnag.json_library().encode!(%{apiKey: api_key, notifier: notifier, events: events})
   end
 
   defp fetch_option(options, key, default \\ nil) do

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Bugsnag.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.13 or ~> 1.0"},
-      {:jason, "~> 1.0"},
+      {:jason, "~> 1.0", optional: true},
+      {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:meck, "~> 0.8.3", only: :test}
     ]

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -216,4 +216,25 @@ defmodule Bugsnag.PayloadTest do
       version: _
     } = get_payload().notifier
   end
+
+  for json_library <- [nil, Jason, Poison] do
+    desc = if json_library, do: inspect(json_library), else: "default JSON library"
+
+    test "it encodes `apiKey` using #{desc}" do
+      json_library = unquote(json_library)
+
+      if json_library do
+        Application.put_env(:bugsnag, :json_library, json_library)
+      else
+        Application.delete_env(:bugsnag, :json_library)
+      end
+
+      decoded_payload =
+        get_payload()
+        |> Payload.encode()
+        |> Bugsnag.json_library().decode!()
+
+      assert decoded_payload["apiKey"] == "FAKEKEY"
+    end
+  end
 end

--- a/test/bugsnag/payload_test.exs
+++ b/test/bugsnag/payload_test.exs
@@ -178,11 +178,11 @@ defmodule Bugsnag.PayloadTest do
   end
 
   test "it sets the API key if configured" do
-    assert "FAKEKEY" == get_payload().apiKey
+    assert "FAKEKEY" == get_payload().api_key
   end
 
   test "it sets the API key from options, even when configured" do
-    assert "anotherkey" == get_payload(api_key: "anotherkey").apiKey
+    assert "anotherkey" == get_payload(api_key: "anotherkey").api_key
   end
 
   test "is sets the device info if given" do

--- a/test/bugsnag_test.exs
+++ b/test/bugsnag_test.exs
@@ -147,4 +147,10 @@ defmodule BugsnagTest do
 
     assert :ok = Bugsnag.sync_report(RuntimeError.exception("some_error"))
   end
+
+  test "uses Jason as JSON library by default" do
+    Application.delete_env(:bugsnag, :json_library)
+
+    assert Bugsnag.json_library() == Jason
+  end
 end


### PR DESCRIPTION
1. #84 introduced a bug. Since Jason cannot encode arbitrary structs, a custom `Jason.Encoder` implementation is required. If a `Jason.Encoder` implementation is [derived](https://github.com/jarednorman/bugsnag-elixir/blob/ebf3569ada87e27f83bc21935fb96f4aab82b23d/lib/bugsnag/payload.ex#L10), only known struct fields are going to be encoded (i.e. `api_key`, `notifier`, `events`). The `Payload.new/3` [constructor](https://github.com/jarednorman/bugsnag-elixir/blob/ebf3569ada87e27f83bc21935fb96f4aab82b23d/lib/bugsnag/payload.ex#L17-L21) puts the `apiKey` field (which is used by the Bugsnag endpoint) into the struct and leaves `api_key` nil. Because of the derived implementation of `Jason.Encoder`, the `apiKey` is always ignored when the payload is encoded to JSON; it produces JSON objects like this:

    ```yaml
    {
      "api_url": null, # always null because `Payload.new/3` never sets this field
      "notifier": ...,
      "events": [...]
    }
    ```
    
    Because the Bugsnag endpoint never receives a valid API key, such reports are silently ignored. This PR fixes this bug.

2. I also made JSON library customizable (Jason is used by default).