### PR TITLE
Remove warning on Elixir 1.10 

### DIFF
--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -33,7 +33,7 @@ defmodule Bugsnag do
     end
 
     children = [
-      supervisor(Task.Supervisor, [[name: Bugsnag.TaskSupervisor, restart: :transient]])
+      supervisor(Task.Supervisor, [[name: Bugsnag.TaskSupervisor]])
     ]
 
     opts = [strategy: :one_for_one, name: Bugsnag.Supervisor]
@@ -48,7 +48,7 @@ defmodule Bugsnag do
     Task.Supervisor.start_child(Bugsnag.TaskSupervisor, __MODULE__, :sync_report, [
       exception,
       add_stacktrace(options)
-    ])
+    ], [restart: :transient])
   end
 
   def json_library(), do: Application.get_env(:bugsnag, :json_library, Jason)


### PR DESCRIPTION
Remove warning on Elixir 1.10  by moving restart option to start_child as recommended:

https://hexdocs.pm/elixir/Task.Supervisor.html#start_link/1