### PR TITLE
feat: Adds additional opts config for HTTP Adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Capture exceptions and send them to the [Bugsnag](https://www.bugsnag.com/) API!
     - [`exception_filter`](#exception_filter)
     - [`json_library`](#json_library)
     - [`http_client`](#http_client)
+    - [`http_client_opts`](#http_client_opts)
   - [Usage](#usage)
     - [Manual Reporting](#manual-reporting)
     - [Reporting Options](#reporting-options)
@@ -131,6 +132,7 @@ config :bugsnag,
   endpoint_url: "https://self-hosted-bugsnag.myapp",
   hostname: {:system, "HOST", "unknown"},
   http_client: MyApp.BugsnagHTTPAdapter,
+  http_client_opts: [ssl: [cacertfile: "/path/to/cacertfile.pem"]],
   in_project: "lib/my_app_name",
   json_library: Jason,
   notify_release_stages: ["staging", "production"],
@@ -294,6 +296,13 @@ The JSON encoding library.
 **Default** `Bugsnag.HTTPClient.Adapters.HTTPoison`
 
 An adapter implementing the `Bugsnag.HTTPClient` behaviour.
+
+### `http_client_opts`
+
+**Default** `[]`
+
+A keyword list of options passed to the calls made with an adapter implementing
+the `Bugsnag.HTTPClient` behaviour.
 
 ## Usage
 

--- a/lib/bugsnag/http_client.ex
+++ b/lib/bugsnag/http_client.ex
@@ -11,10 +11,14 @@ defmodule Bugsnag.HTTPClient do
   @callback post(Request.t()) :: success() | failure()
 
   def post(request) do
-    adapter().post(request)
+    http_client().post(%{request | opts: http_client_opts() ++ request.opts})
   end
 
-  defp adapter do
+  defp http_client do
     Application.get_env(:bugsnag, :http_client, HTTPoison)
+  end
+
+  defp http_client_opts do
+    Application.get_env(:bugsnag, :http_client_opts, [])
   end
 end

--- a/lib/bugsnag/http_client/adapters/httpoison.ex
+++ b/lib/bugsnag/http_client/adapters/httpoison.ex
@@ -11,8 +11,11 @@ if Code.ensure_loaded?(HTTPoison) do
 
     @impl true
     def post(%Request{} = request) do
+      configuration = Application.get(:bugsnag, __MODULE__, [])
+      additional_opts = Keyword.get(configuration, :additional_opts, [])
+
       request.url
-      |> HTTPoison.post(request.body, request.headers, request.opts)
+      |> HTTPoison.post(request.body, request.headers, request.opts ++ additional_opts)
       |> case do
         {:ok, %{body: body, headers: headers, status_code: status}} ->
           {:ok, Response.new(status, headers, body)}

--- a/lib/bugsnag/http_client/adapters/httpoison.ex
+++ b/lib/bugsnag/http_client/adapters/httpoison.ex
@@ -11,11 +11,8 @@ if Code.ensure_loaded?(HTTPoison) do
 
     @impl true
     def post(%Request{} = request) do
-      configuration = Application.get_env(:bugsnag, __MODULE__, [])
-      additional_opts = Keyword.get(configuration, :additional_opts, [])
-
       request.url
-      |> HTTPoison.post(request.body, request.headers, request.opts ++ additional_opts)
+      |> HTTPoison.post(request.body, request.headers, request.opts)
       |> case do
         {:ok, %{body: body, headers: headers, status_code: status}} ->
           {:ok, Response.new(status, headers, body)}

--- a/lib/bugsnag/http_client/adapters/httpoison.ex
+++ b/lib/bugsnag/http_client/adapters/httpoison.ex
@@ -11,7 +11,7 @@ if Code.ensure_loaded?(HTTPoison) do
 
     @impl true
     def post(%Request{} = request) do
-      configuration = Application.get(:bugsnag, __MODULE__, [])
+      configuration = Application.get_env(:bugsnag, __MODULE__, [])
       additional_opts = Keyword.get(configuration, :additional_opts, [])
 
       request.url


### PR DESCRIPTION
Without some way to pass in more options, I can't use my instance's SSL CA.