### PR TITLE
feat: Adds a logger backend (Ready for Review)

### DIFF
--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -1,12 +1,17 @@
 defmodule Bugsnag do
-  use Application
+  alias Bugsnag.LoggerBackend
   require Logger
+  use Application
 
   def start(_type, _args) do
     config = load_config()
 
     if use_logger?(config) do
       :error_logger.add_report_handler(Bugsnag.Logger)
+    end
+
+    if add_backend?(config) do
+      Logger.add_backend(LoggerBackend)
     end
 
     # Update Application config with evaluated configuration
@@ -58,6 +63,7 @@ defmodule Bugsnag do
       api_key: {:system, "BUGSNAG_API_KEY", nil},
       endpoint_url: {:system, "BUGSNAG_ENDPOINT_URL", "https://notify.bugsnag.com"},
       use_logger: {:system, "BUGSNAG_USE_LOGGER", true},
+      add_backend: {:system, "BUGSNAG_ADD_BACKEND", true},
       release_stage: {:system, "BUGSNAG_RELEASE_STAGE", "production"},
       notify_release_stages: {:system, "BUGSNAG_NOTIFY_RELEASE_STAGES", ["production"]},
       hostname: {:system, "BUGSNAG_HOSTNAME", "unknown"},
@@ -82,5 +88,9 @@ defmodule Bugsnag do
 
   defp use_logger?(config) do
     not is_nil(config[:api_key]) and to_string(config[:use_logger]) == "true"
+  end
+
+  defp add_backend?(config) do
+    not is_nil(config[:api_key]) and to_string(config[:add_backend]) == "true"
   end
 end

--- a/lib/bugsnag/logger_backend.ex
+++ b/lib/bugsnag/logger_backend.ex
@@ -1,22 +1,5 @@
-defmodule Bugsnag.LoggerBackend.GuardShim do
-  defmacro is_exception(term) do
-    if function_exported?(Kernel, :is_exception, 1) do
-      quote do
-        Kernel.is_exception(unquote(term))
-      end
-    else
-      quote do
-        Kernel.is_map_key(unquote(term), :__exception__)
-      end
-    end
-  end
-end
-
 defmodule Bugsnag.LoggerBackend do
   require Logger
-
-  import Kernel, except: [is_exception: 1]
-  import Bugsnag.LoggerBackend.GuardShim
 
   @behaviour :gen_event
 
@@ -37,7 +20,7 @@ defmodule Bugsnag.LoggerBackend do
         {{:nocatch, _term}, _stacktrace} ->
           {:ok, options}
 
-        {exception, stacktrace} when is_exception(exception) ->
+        {%{__exception__: _module} = exception, stacktrace} ->
           Bugsnag.sync_report(exception, stacktrace: stacktrace)
           {:ok, options}
 

--- a/lib/bugsnag/logger_backend.ex
+++ b/lib/bugsnag/logger_backend.ex
@@ -1,9 +1,10 @@
-if function_exported?(Kernel, :is_exception, 1) do
-  defmodule Bugsnag.LoggerBackend.GuardShim do
-  end
-else
-  defmodule Bugsnag.LoggerBackend.GuardShim do
-    defmacro is_exception(term) do
+defmodule Bugsnag.LoggerBackend.GuardShim do
+  defmacro is_exception(term) do
+    if function_exported?(Kernel, :is_exception, 1) do
+      quote do
+        is_exception(unquote(term))
+      end
+    else
       quote do
         is_map_key(unquote(term), :__exception__)
       end

--- a/lib/bugsnag/logger_backend.ex
+++ b/lib/bugsnag/logger_backend.ex
@@ -1,5 +1,20 @@
+if function_exported?(Kernel, :is_exception, 1) do
+  defmodule Bugsnag.LoggerBackend.GuardShim do
+  end
+else
+  defmodule Bugsnag.LoggerBackend.GuardShim do
+    defmacro is_exception(term) do
+      quote do
+        is_map_key(unquote(term), :__exception__)
+      end
+    end
+  end
+end
+
 defmodule Bugsnag.LoggerBackend do
   require Logger
+
+  import Bugsnag.LoggerBackend.GuardShim
 
   @behaviour :gen_event
 
@@ -22,6 +37,7 @@ defmodule Bugsnag.LoggerBackend do
 
         {exception, stacktrace} when is_exception(exception) ->
           Bugsnag.sync_report(exception, stacktrace: stacktrace)
+          {:ok, options}
 
         {_exit_value, _stacktrace} ->
           {:ok, options}

--- a/lib/bugsnag/logger_backend.ex
+++ b/lib/bugsnag/logger_backend.ex
@@ -2,11 +2,11 @@ defmodule Bugsnag.LoggerBackend.GuardShim do
   defmacro is_exception(term) do
     if function_exported?(Kernel, :is_exception, 1) do
       quote do
-        is_exception(unquote(term))
+        Kernel.is_exception(unquote(term))
       end
     else
       quote do
-        is_map_key(unquote(term), :__exception__)
+        Kernel.is_map_key(unquote(term), :__exception__)
       end
     end
   end

--- a/lib/bugsnag/logger_backend.ex
+++ b/lib/bugsnag/logger_backend.ex
@@ -1,0 +1,35 @@
+defmodule Bugsnag.LoggerBackend do
+  @behaviour :gen_event
+
+  @impl :gen_event
+  def init(__MODULE__) do
+    {:ok, []}
+  end
+
+  @impl :gen_event
+  def handle_call({:configure, new_options}, options) do
+    {:ok, :ok, Keyword.merge(options, new_options)}
+  end
+
+  @impl :gen_event
+  def handle_event({_level, _group_leader, {Logger, message, timestamp, metadata}}, options) do
+    if Keyword.has_key?(metadata, :crash_reason) do
+      case metadata[:crash_reason] do
+        {{:nocatch, _term}, _stacktrace} ->
+          {:ok, options}
+
+        {exception, stacktrace} when is_exception(exception) ->
+          Bugsnag.report(exception, stacktrace: stacktrace)
+
+        {_exit, stacktrace} ->
+          {:ok, options}
+      end
+    else
+      {:ok, options}
+    end
+  end
+
+  def handle_event(_, options) do
+    {:ok, options}
+  end
+end

--- a/lib/bugsnag/logger_backend.ex
+++ b/lib/bugsnag/logger_backend.ex
@@ -15,6 +15,7 @@ end
 defmodule Bugsnag.LoggerBackend do
   require Logger
 
+  import Kernel, except: [is_exception: 1]
   import Bugsnag.LoggerBackend.GuardShim
 
   @behaviour :gen_event

--- a/test/bugsnag/logger_backend_test.exs
+++ b/test/bugsnag/logger_backend_test.exs
@@ -59,8 +59,12 @@ defmodule Bugsnag.LoggerBackendTest do
     ref = make_ref()
 
     Mox.expect(HTTPMock, :post, fn %Request{body: body} ->
-      if exception?(body, "Elixir.ArgumentError", "not a textual representation of a float") do
-        send(parent, {:post, ref})
+      cond do
+        exception?(body, "Elixir.ArgumentError", "argument error") ->
+          send(parent, {:post, ref})
+
+        exception?(body, "Elixir.ArgumentError", "not a textual representation of a float") ->
+          send(parent, {:post, ref})
       end
 
       {:ok, Response.new(200, [], "body")}

--- a/test/bugsnag/logger_backend_test.exs
+++ b/test/bugsnag/logger_backend_test.exs
@@ -1,4 +1,4 @@
-defmodule Bugsnag.LoggerTest do
+defmodule Bugsnag.LoggerBackendTest do
   use ExUnit.Case
 
   alias Bugsnag.HTTPMock
@@ -6,6 +6,7 @@ defmodule Bugsnag.LoggerTest do
   alias Bugsnag.HTTPClient.Response
   import ExUnit.CaptureLog
   import Mox
+  require Logger
 
   @receive_timeout 5_000
 
@@ -28,31 +29,11 @@ defmodule Bugsnag.LoggerTest do
   end
 
   setup do
-    :error_logger.add_report_handler(Bugsnag.Logger)
+    Logger.add_backend(Bugsnag.LoggerBackend)
 
     on_exit(fn ->
-      :error_logger.delete_report_handler(Bugsnag.Logger)
+      Logger.remove_backend(Bugsnag.LoggerBackend)
     end)
-  end
-
-  test "logging a crash" do
-    parent = self()
-    ref = make_ref()
-
-    Mox.expect(HTTPMock, :post, fn %Request{body: body} ->
-      if exception?(body, "Elixir.RuntimeError", "Oh noes") do
-        send(parent, {:post, ref})
-      end
-
-      {:ok, Response.new(200, [], "body")}
-    end)
-
-    :proc_lib.spawn(fn ->
-      raise RuntimeError, "Oh noes"
-    end)
-
-    assert_receive {:post, ^ref}, @receive_timeout
-    verify!()
   end
 
   test "crashes do not cause recursive logging" do
@@ -67,47 +48,7 @@ defmodule Bugsnag.LoggerTest do
       {:ok, Response.new(500, [], "body")}
     end)
 
-    error_report = [[error_info: {:error, %RuntimeError{message: "Oops"}, []}], []]
-    :error_logger.error_report(error_report)
-
-    assert_receive {:post, ^ref}, @receive_timeout
-    verify!()
-  end
-
-  test "log levels lower than :error_report are ignored" do
-    parent = self()
-    ref = make_ref()
-
-    Mox.expect(HTTPMock, :post, 0, fn _request ->
-      send(parent, {:post, ref})
-      {:error, :just_no}
-    end)
-
-    message_types = [:info_msg, :info_report, :warning_msg, :error_msg]
-
-    Enum.each(message_types, fn type ->
-      apply(:error_logger, type, ["Ignore me"])
-    end)
-
-    refute_receive {:post, ^ref}, @receive_timeout
-    verify!()
-  end
-
-  test "logging exceptions from special processes" do
-    parent = self()
-    ref = make_ref()
-
-    Mox.expect(HTTPMock, :post, fn %Request{body: body} ->
-      if exception?(body, "Elixir.ArgumentError", "argument error") do
-        send(parent, {:post, ref})
-      end
-
-      {:ok, Response.new(200, [], "body")}
-    end)
-
-    :proc_lib.spawn(fn ->
-      Float.parse("12.345e308")
-    end)
+    Logger.error("Oops", crash_reason: {%RuntimeError{message: "Oops"}, []})
 
     assert_receive {:post, ^ref}, @receive_timeout
     verify!()
@@ -118,7 +59,7 @@ defmodule Bugsnag.LoggerTest do
     ref = make_ref()
 
     Mox.expect(HTTPMock, :post, fn %Request{body: body} ->
-      if exception?(body, "Elixir.ArgumentError", "argument error") do
+      if exception?(body, "Elixir.ArgumentError", "not a textual representation of a float") do
         send(parent, {:post, ref})
       end
 
@@ -153,11 +94,11 @@ defmodule Bugsnag.LoggerTest do
   end
 
   test "warns if error report format is invalid" do
-    event = {:error_report, :gl, {:pid, :type, [[error_info: :invalid]]}}
+    event = {:error, self(), {Logger, "", nil, [crash_reason: {:a, :triple, :tuple}]}}
 
     log_msg =
       capture_log(fn ->
-        Bugsnag.Logger.handle_event(event, :state)
+        Bugsnag.LoggerBackend.handle_event(event, :state)
       end)
 
     assert log_msg =~ "Unable to notify Bugsnag. ** (CaseClauseError)"

--- a/test/bugsnag/logger_backend_test.exs
+++ b/test/bugsnag/logger_backend_test.exs
@@ -65,6 +65,9 @@ defmodule Bugsnag.LoggerBackendTest do
 
         exception?(body, "Elixir.ArgumentError", "not a textual representation of a float") ->
           send(parent, {:post, ref})
+
+        true ->
+          nil
       end
 
       {:ok, Response.new(200, [], "body")}

--- a/test/bugsnag/logger_test.exs
+++ b/test/bugsnag/logger_test.exs
@@ -98,8 +98,12 @@ defmodule Bugsnag.LoggerTest do
     ref = make_ref()
 
     Mox.expect(HTTPMock, :post, fn %Request{body: body} ->
-      if exception?(body, "Elixir.ArgumentError", "argument error") do
-        send(parent, {:post, ref})
+      cond do
+        exception?(body, "Elixir.ArgumentError", "argument error") ->
+          send(parent, {:post, ref})
+
+        exception?(body, "Elixir.ArgumentError", "not a textual representation of a float") ->
+          send(parent, {:post, ref})
       end
 
       {:ok, Response.new(200, [], "body")}

--- a/test/bugsnag/logger_test.exs
+++ b/test/bugsnag/logger_test.exs
@@ -104,6 +104,9 @@ defmodule Bugsnag.LoggerTest do
 
         exception?(body, "Elixir.ArgumentError", "not a textual representation of a float") ->
           send(parent, {:post, ref})
+
+        true ->
+          nil
       end
 
       {:ok, Response.new(200, [], "body")}


### PR DESCRIPTION
The error logger integration wasn't working when I tested on the following versions:
| language | version |
|----------|--------|
| elixir        | 1.12.3 |
| erlang      |   24.1 |

I added a Logger Backend, which should still work with previous versions. If you like the way this works, I think we can safely replace the `error_logger` based integration with this integration.